### PR TITLE
Fix Issue #2

### DIFF
--- a/main/Gui/spectrum.tcl
+++ b/main/Gui/spectrum.tcl
@@ -773,6 +773,11 @@ snit::widget readSpectrumDialog {
     oncget -bind     {
         return [GetCheckButton $win.bind]
     }
+    # getFilter - get the filter mask:
+    #
+    method getFilter {} {
+	$filebox cget -mask
+    }
 
 
     proc SetCheckButton {widget value} {
@@ -1274,7 +1279,7 @@ proc readSpectrumFile {} {
 
         if {$file != ""} {
             if {[file dirname $file] == "."} {
-                set filter [.savemany getFilter]
+                set filter [.readmany getFilter]
                 set dir    [file dirname $filter]
                 set file   [file join $dir $file]
             }


### PR DESCRIPTION
*   Added getFilter to the read spectrum dialog box which was missing
since file prompting was done very differently than for read spectrum.
*   Fix typo  in reading spectra... getFilter called on the wrong widget.