### PR TITLE
Issue #4 - support differing shared memory types

### DIFF
--- a/main/Display/Makefile.am
+++ b/main/Display/Makefile.am
@@ -101,7 +101,7 @@ lexsupport.c
 
 
 
-libXamine_la_LDFLAGS = -version-info $(SOVERSION):0
+libXamine_la_LDFLAGS = -version-info $(SOVERSION):0 $(RTLIB)
 
 libXamine_la_SOURCES = client.c clientgates.c  allocator.c \
     specalloc.c clientbuttons.c prccheck.c
@@ -185,7 +185,7 @@ Xamine_DEPENDENCIES = menusetup.o exit.o helpmenu.o winiomenu.o \
 #Xaminetest_DEPENDENCIES = libXamine.la
 
 
-Xamine_LDFLAGS=  -g
+Xamine_LDFLAGS=  -g $(RTLIB)
 Xamine_LDADD=  @top_builddir@/XamineParsers/libXamineParsers.la @XLIBSW@ @MOTIF_LIBSW@ @XTLIBSW@ @GDLDSW@  \
 		@TK_LIBS@ @TCL_LIBS@ 						\
 			-lXm -lXt -lX11 -lm  $(X11EXTRA_LDFLAGS)

--- a/main/configure.ac
+++ b/main/configure.ac
@@ -1,6 +1,6 @@
 # Process this file with autoconf to produce a configure script.
 
-AC_INIT(SpecTcl,5.13-004, daqhelp@frib.msu.edu)
+AC_INIT(SpecTcl,5.13-005, daqhelp@frib.msu.edu)
 
 #AC_CONFIG_SRCDIR(SpecTcl/MySpecTclApp.cpp)
 AC_CONFIG_AUX_DIR(config)
@@ -102,8 +102,9 @@ AC_CHECK_LIB(m, pow)
 AC_CHECK_LIB(m, sqrt)
 AC_CHECK_LIB(m, logb)
 AC_CHECK_FUNCS([strdup strstr strtol tzset mktime strtod timezone])
-
-
+AC_CHECK_LIB(rt, shm_open, [RTLIB=-lrt
+AC_DEFINE([HAVE_SHM_OPEN], [1])],[RTLIB=""])
+AC_SUBST(RTLIB)
 
 
 #  The following are needed for strict ANSI c++ compilers The major features


### PR DESCRIPTION
*  Update configure.ac and DisplayMakefile.am - If POSIX shared memory is supportred., the libraries are defined and pulled into Xamine client libs and Xamine. - Set the version to 5.13-005
*   Support Xamine mapping to any type of shared memory using type:name in the
XAMINE_SHMEM env variable
*   Remove  a bunch of #ifdefery in client shared memory creation to force SYSV.