### PR TITLE
Rfoxkendo/issue60

### DIFF
--- a/main/Display/allocator.c
+++ b/main/Display/allocator.c
@@ -29,9 +29,9 @@
 ** data structures used:
 */
 typedef struct _node {
-                 struct _node *next;
-		 long          size;
-	       } node;			/* memory node. */
+     struct _node *next;
+		 size_t        size;
+} node;			/* memory node. */
 
 /* 
 ** Local storage: 
@@ -107,7 +107,7 @@ static void remove(arenaid arena, node *st_node)
 ** Formal Parameters:
 **   caddr_t arena:
 **     Points to the arena to manage.
-**   int size:
+**   size_t size:
 **     the number of bytes in the arena.
 ** returns:
 **    caddr_t arena_id:
@@ -115,7 +115,7 @@ static void remove(arenaid arena, node *st_node)
 **      This will be NULL If the arena control block could not be allocated
 **      and filled in.
 */
-arenaid alloc_init(caddr_t arena, int size)
+arenaid alloc_init(caddr_t arena, size_t size)
 {
   node **first;
 
@@ -161,7 +161,7 @@ longmask()
 ** NOTE: In order to ensure spectrum boundary alignment, all
 **      size requests get increased to the next longword unit.
 */
-caddr_t alloc_get(arenaid arena_id, int size)
+caddr_t alloc_get(arenaid arena_id, size_t size)
 {
   
   
@@ -183,7 +183,7 @@ caddr_t alloc_get(arenaid arena_id, int size)
     }
     if(free->size > largest->size)
       largest = free;
-    free = free->next;
+      free = free->next;
   } while (free != (node *)NULL);
   
   /* When control falls here, largest points to the largest 
@@ -199,7 +199,7 @@ caddr_t alloc_get(arenaid arena_id, int size)
   
   {
     node *st_node;		/* Will point to block storage node. */
-    char *block;		/* WIll point to the user storage.   */
+    char *block;	  	/* Will point to the user storage.   */
 
     block = (char *)largest;
     block += (largest->size - size); /* Points to node part of user storage */

--- a/main/Display/allocator.h
+++ b/main/Display/allocator.h
@@ -41,8 +41,8 @@
 typedef caddr_t *arenaid;
 
 
-arenaid alloc_init(caddr_t arena, int size); /* Initialize an arena */
-caddr_t alloc_get(arenaid arena_id, int size); /* Allocate memory. */
+arenaid alloc_init(caddr_t arena, size_t size); /* Initialize an arena */
+caddr_t alloc_get(arenaid arena_id, size_t size); /* Allocate memory. */
 void    alloc_free(arenaid arena_id, caddr_t storage); /* Free memory. */
 void    alloc_done(arenaid arena_id); /* End use of an arena.     */
 

--- a/main/Display/client.c
+++ b/main/Display/client.c
@@ -99,7 +99,7 @@
 */
 
 volatile Xamine_shared *Xamine_memory;
-int            Xamine_memsize;
+size_t            Xamine_memsize;
 arenaid        Xamine_memory_arena;
 /*
 ** Local storage:
@@ -363,7 +363,7 @@ PrintOffsets()
 
 }
 
-int Xamine_CreateSharedMemory(int specbytes,volatile Xamine_shared **ptr)
+int Xamine_CreateSharedMemory(size_t specbytes,volatile Xamine_shared **ptr)
 {
 
   char name[33];
@@ -637,7 +637,7 @@ int f77xamine_mapmemory_(char *name, int *specbytes,
 **  Xamine_MapMemory which is described by the comment header way up there
 ** It's completely system dependent.
 */
-int Xamine_MapMemory(char *name, int specbytes,volatile Xamine_shared **ptr)
+int Xamine_MapMemory(char *name, size_t specbytes,volatile Xamine_shared **ptr)
 #ifdef HAVE_WINDOWS_H
 {
   HANDLE hMapFile;
@@ -672,7 +672,7 @@ int Xamine_MapMemory(char *name, int specbytes,volatile Xamine_shared **ptr)
 }
 #else
 {
-  int memsize;
+  size_t memsize;
   key_t key;
   int shmid;
 

--- a/main/Display/client.c
+++ b/main/Display/client.c
@@ -80,7 +80,7 @@
 
 #define NAME_FORMAT "XA%02x"
 #define SHARENV_FORMAT "XAMINE_SHMEM=%s" /* Environment names/logical names. */
-#define SIZEENV_FORMAT "XAMINE_SHMEM_SIZE=%d"
+#define SIZEENV_FORMAT "XAMINE_SHMEM_SIZE=%uld"
 
 #define XAMINEENV_FILENAME "XAMINE_IMAGE"
 
@@ -281,7 +281,7 @@ static int genmem(char *name, volatile void **ptr, unsigned int size)
 **    False   - Failure
 */
 
-static int genenv(const char *name, int specbytes)
+static int genenv(const char *name, size_t specbytes)
 {
   /* Allocate persistent storage for the strings */
 

--- a/main/Display/client.h
+++ b/main/Display/client.h
@@ -43,7 +43,7 @@ extern "C" {
 
 /* Create Shared Memory -- Creates the shared memory region for Xamine */
 
-int Xamine_CreateSharedMemory(int specbytes, volatile Xamine_shared **ptr);
+int Xamine_CreateSharedMemory(size_t specbytes, volatile Xamine_shared **ptr);
 int f77xamine_createsharedmemory_(int *specbytes,volatile Xamine_shared **ptr);
 int Xamine_DetachSharedMemory();
 void Xamine_KillSharedMemory();
@@ -64,7 +64,7 @@ int f77xamine_alive_();
 void Xamine_GetMemoryName(char *namebuffer);
 void f77xamine_getmemoryname_(char *namebuffer, int maxlen);
 
-int Xamine_MapMemory(char *name, int specbytes, volatile Xamine_shared **ptr);
+int Xamine_MapMemory(char *name, size_t specbytes, volatile Xamine_shared **ptr);
 int f77xamine_mapmemory_(char *name, int *specbytes,
 			 volatile Xamine_shared **ptr, int namesize);
 

--- a/main/Display/shared.cc
+++ b/main/Display/shared.cc
@@ -308,6 +308,7 @@ static const char* Copyright = "(C) Copyright Michigan State University 1994, Al
 
 #include <sys/types.h>
 #include <unistd.h>
+
 #include <string>
 #include <stdexcept>
 #include <sstream>
@@ -361,7 +362,7 @@ extern volatile  spec_shared *spectra;
 ** Static defs:
 */
 
-static int memsize;
+static size_t memsize;
 
 /** 
  * Types of shared memory supported:
@@ -460,7 +461,7 @@ AnalyzeMemoryName(const char *name)
 ** Returns:
 **   Pointer to the shared memory or NULL on failure.
 */
-static spec_shared *mapmemory(char *name, unsigned int size)
+static spec_shared *mapmemory(char *name, size_t size)
 {
   SharedMemorySpecification spec;
   try {
@@ -681,7 +682,7 @@ void Xamine_initspectra()
 {
   char *name;
   char *size_string;
-  unsigned int size;
+  size_t size;
 
 
 
@@ -699,11 +700,12 @@ void Xamine_initspectra()
   }
   /* Now convert the size string to a number: */
 
-  size = atoi(size_string);
+  size = atoll(size_string);
   if(size == 0) {
     fprintf(stderr, "Xamine -- Shared memory size string was illegal\n");
     exit(-1);
   }
+  fprintf(stderr, "Shared memory '%s' size: %ld\n", size_string, size);
 
   /* Now map to the memory: */
 

--- a/main/configure.ac
+++ b/main/configure.ac
@@ -1,7 +1,7 @@
 # Process this file with autoconf to produce a configure script.
 
 
-AC_INIT(SpecTcl,5.14-pre1, daqhelp@frib.msu.edu)
+AC_INIT(SpecTcl,5.14-000, daqhelp@frib.msu.edu)
 
 #AC_CONFIG_SRCDIR(SpecTcl/MySpecTclApp.cpp)
 AC_CONFIG_AUX_DIR(config)


### PR DESCRIPTION
Fixes issues Xamine/SpecTcl have for 'large' shared memory regions in the 2Gbyte  - 4GByte range.