### PR TITLE
Issue #63 - Not all spectrum classes do indexing for ::set and ::oper…

### DIFF
--- a/main/Core/CSpectrum2DmW.cpp
+++ b/main/Core/CSpectrum2DmW.cpp
@@ -177,7 +177,7 @@ CSpectrum2DmW::set(const UInt_t* pIndices, ULong_t nValue)
   TH1* pRootSpectrum = getRootSpectrum();
   
   pRootSpectrum->SetBinContent(
-    pRootSpectrum->GetBin(x,y), static_cast<Double_t>(nValue)
+    pRootSpectrum->GetBin(x+1,y+1), static_cast<Double_t>(nValue)
   );
 }
 

--- a/main/Core/Gamma1DL.cpp
+++ b/main/Core/Gamma1DL.cpp
@@ -239,7 +239,7 @@ CGamma1DL::set (const UInt_t* pIndices, ULong_t nValue)
 {
   UInt_t* pStorage = (UInt_t*)getStorage();
   Double_t n = pIndices[0];
-  Int_t  bin = m_pRootSpectrum->GetBin(n);
+  Int_t  bin = m_pRootSpectrum->GetBin(n+1);
   m_pRootSpectrum->SetBinContent(n, static_cast<Double_t>(nValue));
 }
 

--- a/main/Core/Gamma1DW.cpp
+++ b/main/Core/Gamma1DW.cpp
@@ -234,7 +234,7 @@ CGamma1DW::set (const UInt_t* pIndices, ULong_t nValue)
     throw CRangeError(0, Dimension(0)-1, n,
 		      std::string("Indexing 1DL gamma spectrum"));
   }
-  Int_t bin = m_pRootSpectrum->GetBin(n);
+  Int_t bin = m_pRootSpectrum->GetBin(n+1);
   m_pRootSpectrum->SetBinContent(n, static_cast<Double_t>(nValue));
 }
 

--- a/main/Core/Gamma2DB.cpp
+++ b/main/Core/Gamma2DB.cpp
@@ -230,7 +230,7 @@ CGamma2DB::set (const UInt_t* pIndices, ULong_t nValue)
     throw CRangeError(0, Dimension(1)-1, ny,
 		      std::string("Indexing 2DB gamma spectrum y axis"));
   }
-  Int_t bin = m_pRootSpectrum->GetBin(nx, ny);
+  Int_t bin = m_pRootSpectrum->GetBin(nx+1, ny+1);
   m_pRootSpectrum->SetBinContent(bin, static_cast<Double_t>(nValue));
 }
 

--- a/main/Core/Gamma2DD.cpp
+++ b/main/Core/Gamma2DD.cpp
@@ -218,7 +218,7 @@ CGamma2DD<T,R>::getSpectrumType()
 */
 template<typename T, typename R>
 ULong_t
-CGamma2DD<T,R>:: operator[](const UInt_t* pIndices) const
+CGamma2DD<T,R>::operator[](const UInt_t* pIndices) const
 {
   Double_t  x = pIndices[0];
   Double_t  y = pIndices[1];
@@ -238,7 +238,7 @@ CGamma2DD<T,R>::set(const UInt_t* pIndices, ULong_t value)
   Double_t  x = pIndices[0];
   Double_t  y = pIndices[1];
   TH1* pRootSpectrum = getRootSpectrum();
-  Int_t   bin = pRootSpectrum->GetBin(x, y);
+  Int_t   bin = pRootSpectrum->GetBin(x+1, y+1);
   pRootSpectrum->SetBinContent(bin, static_cast<Double_t>(value));
 }
 

--- a/main/Core/Gamma2DL.cpp
+++ b/main/Core/Gamma2DL.cpp
@@ -235,7 +235,7 @@ CGamma2DL::set (const UInt_t* pIndices, ULong_t nValue)
     throw CRangeError(0, Dimension(1)-1, ny,
 		      std::string("Indexing 2DW gamma spectrum y axis"));
   }
-  Int_t bin = m_pRootSpectrum->GetBin(nx, ny);
+  Int_t bin = m_pRootSpectrum->GetBin(nx+1, ny+1);
   m_pRootSpectrum->SetBinContent(nx, ny, static_cast<Double_t>(nValue));
 }
 

--- a/main/Core/Makefile.am
+++ b/main/Core/Makefile.am
@@ -188,8 +188,8 @@ Sorter_SRC =  DictionaryException.cpp Histogrammer.cpp Spectrum.cpp \
 	SummarySpectrumB.cpp SpectrumFactory.cpp SpectrumFactoryException.cpp \
 	SnapshotSpectrum.cpp Gamma1DW.cpp Gamma1DL.cpp Gamma2DW.cpp \
 	CGammaSpectrum.cpp \
-	Gamma2DB.cpp GateMediator.cpp CAxis.cpp CParameterMapping.cpp  Parameter.cpp \
-	SpectrumS.cpp \
+	Gamma2DB.cpp GateMediator.cpp CAxis.cpp CParameterMapping.cpp  \
+	 Parameter.cpp SpectrumS.cpp \
 	Spectrum2DL.cpp Gamma2DL.cpp  SummarySpectrumL.cpp \
 	CSpectrum2Dm.cpp CSpectrum2DmL.cpp CSpectrum2DmW.cpp CSpectrum2DmB.cpp \
 	Gamma2DD.cpp CFlattenedGateList.cpp CSpectrumByParameter.cpp \


### PR DESCRIPTION
#issue 63

The classes in this commit had the appropriate +1 done on the indices to their ::operator[] and ::set methods to account for Root's underflow channel which is bin 0.