### PR TITLE
Issue #60 - Large spectrum storage fails.

### DIFF
--- a/main/Display/client.c
+++ b/main/Display/client.c
@@ -797,13 +797,15 @@ void f77xamine_freememory_(int *loc)
 void Xamine_DescribeSpectrum(int spno, int xdim, int ydim, const char *title,
 			     caddr_t loc, spec_type type)
 {
-  int channels;
-  int bpc;
-  int bytes;
+  unsigned int channels;
+  unsigned int bpc;
+  unsigned int bytes;
   unsigned long spec;
   unsigned long  base = (unsigned long)Xamine_memory->dsp_spectra.XAMINE_b;
-  int offset;
+  unsigned int offset;
 
+
+  
   /*
   ** Adjust the spectrum number and range check it:
   */

--- a/main/Display/spectra.cc
+++ b/main/Display/spectra.cc
@@ -379,18 +379,19 @@ unsigned int spec_shared::getchannel(int id, int ix, int iy) volatile
 **/
 volatile unsigned int *spec_shared::getbase(int id) volatile
 {
+  size_t offset = dsp_offsets[id-1];
   volatile unsigned int *base;
   switch(gettype(id)) {
   case twodlong:
   case onedlong:
-    base =  &(dsp_spectra.XAMINE_l[dsp_offsets[id-1]]);
+    base =  &(dsp_spectra.XAMINE_l[offset]);
     break;
   case onedword:
   case twodword:
-    base =  (unsigned int *)&(dsp_spectra.XAMINE_w[dsp_offsets[id-1]]);
+    base =  (unsigned int *)&(dsp_spectra.XAMINE_w[offset]);
     break;
   case twodbyte:
-    base = (unsigned int *)&(dsp_spectra.XAMINE_b[dsp_offsets[id-1]]);
+    base = (unsigned int *)&(dsp_spectra.XAMINE_b[offset]);
     break;
   case undefined:
   default:


### PR DESCRIPTION
Found more cases of errors in offset computation due to ints not unsigned ints - The one that matters, I think is in spectra.cc