### PR TITLE
Document that v1.1 is the CutiePie version to use in

### DIFF
--- a/main/qtpi-incorp.sh
+++ b/main/qtpi-incorp.sh
@@ -6,7 +6,7 @@
 # Where:
 #    tag is the tag to incorporate.
 #
-#  last tag was v0.2.1
+#  last tag was v1.1
 REPOSITORY=https://github.com/FRIBDAQ/CutiePie.git
 TARGET=PyQtGUI
 VERSION=$1


### PR DESCRIPTION
Document that the last (first good?) version of CutiPie to incorporate is version 1.1 as that includes a LICENSE file and proper(?) handling of the Qt5 open source license use.