### PR TITLE
Rfoxkendo/issue99  Resolve the fact that projections of m2 were done incorrectly.

### DIFF
--- a/main/Core/CM2Projection.hpp
+++ b/main/Core/CM2Projection.hpp
@@ -187,7 +187,11 @@ CM2Projection<T,R>::UsesParameter(UInt_t id) const
 {
     for (int i = 0; i < m_XYParameterPairs.size(); i++) {
         const std::pair<UInt_t, UInt_t>& xy(m_XYParameterPairs[i]);
-        if ((id == xy.first) || (id == xy.second)) return kfTRUE;
+        if(m_x) {
+            if (id == xy.first) return kfTRUE;
+        } else {
+            if (id == xy.second) return kfFALSE;
+        }
     }
     return kfFALSE;
 }
@@ -205,8 +209,12 @@ CM2Projection<T,R>::GetParameterIds(std::vector<UInt_t>& ids)
     ids.clear();
     for (int i = 0; i < m_XYParameterPairs.size(); i++) {
         std::pair<UInt_t, UInt_t>& xy(m_XYParameterPairs[i]);
-        ids.push_back(xy.first);
-        ids.push_back(xy.second);
+        if (m_x) {
+            ids.push_back(xy.first);
+        } else {
+            ids.push_back(xy.second);
+        }
+        
     }
 }
 /**

--- a/main/Core/CProjectionCommand.cpp
+++ b/main/Core/CProjectionCommand.cpp
@@ -445,10 +445,18 @@ CProjectionCommand::getValidatedTargetSpectrum(const char* name,
     
     
     vector<CParameter> parameters;
+    vector<CParameter> gsParameters;     // Different params if we're -> g1:
+    bool xproj = which == x ? kfTRUE : kfFALSE;
     for (int i = 0; i < def.vParameters.size(); i ++) {
       CParameter* pParam = api->FindParameter(def.vParameters[i]);
       REQUIRE(pParam, "Parameter lookup failed");
       parameters.push_back(*pParam);
+      if (xproj && (i %2 == 0)) {   // Even params are x-s
+        gsParameters.push_back(*pParam);
+      }
+      if (!xproj && (i%2 == 1)) {   // Odd params are y-s.
+      gsParameters.push_back(*pParam);
+      }
     }
     // If the type is ke2Dm and the gate container is not the true container
     // we need tomake an m2 projection spectrum.   Otherwise a g1d is just fine.
@@ -456,12 +464,12 @@ CProjectionCommand::getValidatedTargetSpectrum(const char* name,
     if ((def.eType == ke2Dm) && gate != &truecontainer) {
         pDest =api->CreateM2Projection(
             std::string(name), keLong, parameters, gate,
-            which == x ? kfTRUE : kfFALSE,
+            xproj,
             nChannels, Low, High
         );
     } else {
         pDest = api->CreateG1D(string(name), keLong, 
-                   parameters,
+                   gsParameters,
                    nChannels, Low, High);
     }
   }

--- a/main/Core/SpectrumPackage.cpp
+++ b/main/Core/SpectrumPackage.cpp
@@ -1877,13 +1877,15 @@ CSpectrumPackage::DescribeSpectrum(CSpectrum& rSpectrum, bool showGate)
     for (int i = 0; i < Def.vParameters.size(); i++) {
         CParameter* xpar = m_pHistogrammer->FindParameter(Def.vParameters[i]);
         CParameter* ypar = m_pHistogrammer->FindParameter(Def.vyParameters[i]);
-        
-        Description.AppendElement(
-            xpar ? xpar->getName() : std::string("--Deleted Parameter--")
-        );
-        Description.AppendElement(
-            ypar ? ypar->getName() : std::string("--Deleted Parameter--")
-        );
+        if (x) {
+          Description.AppendElement(
+              xpar ? xpar->getName() : std::string("--Deleted Parameter--")
+          );
+        } else {
+          Description.AppendElement(
+              ypar ? ypar->getName() : std::string("--Deleted Parameter--")
+          );
+        }
     }
     Description.EndSublist();
     

--- a/main/Core/factoryTests.cpp
+++ b/main/Core/factoryTests.cpp
@@ -157,9 +157,8 @@ FactoryTests::constructok()
     // Be sure the spectrum is right.
     
     std::vector<UInt_t> paramIds;  pSpec->GetParameterIds(paramIds);
-    EQ(size_t(2), paramIds.size());
-    EQ(UInt_t(1), paramIds[0]);
-    EQ(UInt_t(2), paramIds[1]);
+    EQ(size_t(1), paramIds.size());
+    EQ(py.getNumber(), paramIds[0]);
     
     EQ(UInt_t(1),     pSpec->Dimensionality());
     EQ(Size_t(128+2), pSpec->Dimension(0));

--- a/main/Core/m2projtest.cpp
+++ b/main/Core/m2projtest.cpp
@@ -231,18 +231,18 @@ void m2projtest::querymethods()
 {
     std::unique_ptr<CM2ProjectionL> p(makeSpectrum()); // avoids leaks.
     
-    // parameters [1,6] are used.
+    // parameters [1,3,5] are 'used' the x ones.
     
-    for (int i =1; i < 7; i++) {
+    for (int i =1; i < 7; i+=2) {
         ASSERT(p->UsesParameter(i));
     }
     // Parameters get returned in 1-6 order:
     
     std::vector<UInt_t> params;
     p->GetParameterIds(params);
-    EQ(size_t(6), params.size());
-    for (UInt_t i =0; i < 6; i++) {
-        EQ(i+1, params[i]);
+    EQ(size_t(3), params.size());
+    for (UInt_t i =0; i < params.size(); i++) {
+        EQ(2*(i)+1, params[i]);
     }
     // only one resolution and it's 128.
     


### PR DESCRIPTION
*  Fix the descriptions of projected, m2s within a gate.
* Fix the construction of projected m2s without a gate (g1 spectra), so that only the correct parameter set was used.