### PR TITLE
Rfoxkendo/issue91 Issue#91 resolved. - 

### DIFF
--- a/main/Core/TestFile.cpp
+++ b/main/Core/TestFile.cpp
@@ -43,7 +43,7 @@ static const char* Copyright = "(C) Copyright Michigan State University 2005, Al
 #include <buffer.h>
 #include <buftypes.h>
 #include <MultiTestSource.h>
-
+#include <DataFormat.h>
 #ifdef HAVE_STD_NAMESPACE
 using namespace std;
 #endif
@@ -122,30 +122,20 @@ Int_t CTestFile::Read(Address_t pBuffer, UInt_t nSize) {
     throw re;
   }
   // The buffer is formatted as follows;
-  // first the header is put in, then as many events as will fit.
-  // finally, the buffersize, and event count are set back into the header.
+  // we put in one nscldaq-11 ring item with no body header per
+  // read:
   //
   UChar_t* p = (UChar_t*)pBuffer;
-  UInt_t  nEvents = 0;
-  UInt_t  nBytes  = 0;
-  UInt_t  n;
-
-  // Put the header in:
+  size_t   n;
+  
   n       = FormatNSCLHeader(p);
-  p      += n; 
-  nBytes += n;  
+  
+  p += n;
+  n       = FormatEvent(p);
+  p += n;
 
-  // Fill the buffer with events (generic).
-  while((nBytes + EventSize()) < nSize) { // Another event fits:
-    n       = FormatEvent(p);
-    p      += n;
-    nBytes += n;  
-    nEvents++;
-  }
-
-  SetEventCount(pBuffer, nEvents);
-  SetBufferSize(pBuffer, nBytes);
-  return nBytes;
+  pRingItemHeader pItem = reinterpret_cast<pRingItemHeader>(pBuffer);
+  return pItem->s_size;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -358,27 +348,17 @@ void CTestFile::DoAssign(const CTestFile& arhs) {
 //  Operation Type:
 //    Utility.
 UInt_t CTestFile::FormatNSCLHeader(Address_t pBuffer) {
-  // Formats an NSCL buffer header into the buffer passed in.
-  //  the buffer must be big enough to handle the header.
+  // Formats an NSCL ring item header with no body headr
   // 
-  // returns the number of bytes put in the buffer.
 
-  BHEADER* pHeader = (BHEADER*)pBuffer;
+
+  pRingItem pHeader = reinterpret_cast<pRingItem>(pBuffer);
+  pHeader->s_header.s_size = sizeof(RingItemHeader) + sizeof(uint32_t) + EventSize();
+  pHeader->s_header.s_type = PHYSICS_EVENT;
+  pHeader->s_body.u_noBodyHeader.s_mbz = sizeof(uint32_t);  // Also works for nscldaq12
   
-  pHeader->nwds = 0;		// Filled in later.
-  pHeader->type = DATABF;	// Data buffer.
-  pHeader->cks  = 0;		// Don't emulate checksum.
-  pHeader->run  = 1;		// Always run # 1.
-  pHeader->seq  = 0;		// Always buffer number 0.
-  pHeader->nevt = 0;		// Filled in later.
-  pHeader->nlam = 0;		// No lam masks.
-  pHeader->cpu  = 1;		// CPU # 1.
-  pHeader->nbit = 0;		// No bit registers.
-  pHeader->buffmt=4;		// Buffer revision level.
-  pHeader->ssignature = 0x0102; // Word byte order signature.
-  pHeader->lsignature = 0x01020304l; // Longword order signature.
 
-  return sizeof(BHEADER);
+  return sizeof(RingItemHeader) + sizeof(uint32_t);
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/main/Gui/folderGui.tcl
+++ b/main/Gui/folderGui.tcl
@@ -238,20 +238,50 @@ proc editPrefs {} {
 #     The error message
 #  
 proc sourceScriptReportingErrors {} {
+    
     set file [tk_getOpenFile -defaultextension .tcl             \
                              -filetypes [list                   \
                                     [list "Tcl Scripts"  .tcl]  \
                                     [list "Tk Scripts"   .tk]   \
+                                    [list "Sqlite3 database" .db] \
                                     [list "All files"    *]]    \
                              -title {Select File to Source}]
-    if {[file readable $file]} {
-	set errors [incrementalSource $file]
-	if {$errors ne ""} {
-	    displayScriptErrors $file $errors
-	}
-        $::FolderGui::folderGuiBrowser update;       # In case the script execution changes something.
-        failsafeWrite
+    
+    if {[file readable $file] && [file extension $file] ne ".db"} {
+	    set errors [incrementalSource $file]
+        if {$errors ne ""} {
+            displayScriptErrors $file $errors
+        }
+    } else {
+        # Restore from a database file:
+
+        if {[file readable $file]} {
+            
+            set db [dbconfig::connect $file]
+            
+            if {[catch {dbconfig::restoreRustogramer $db} msg]} {
+                tk_messageBox \
+                    -icon error \
+                    -parent $::FolderGui::folderGuiBrowser \
+                    -type Ok \
+                    -title "restore failed" \
+                    -message "Could not restore configure from database $file : $msg"
+            }
+            
+            $db destroy
+            sbind -all
+        } else {
+            tk_messageBox \
+                -icon error \
+                -parent $::FolderGui::folderGuiBrowser \
+                -type Ok \
+                -title "No such file" \
+                -message "$file does not exist"
+        }
     }
+    $::FolderGui::folderGuiBrowser update;       # In case the script execution changes something.
+    failsafeWrite
+
 }
 
 #sourceScript

--- a/main/Gui/folderGui.tcl
+++ b/main/Gui/folderGui.tcl
@@ -151,14 +151,15 @@ proc getLine fd {
     set lines 0
 
     while {![eof $fd]} {
-	gets $fd fragment
-	incr lines
-	if {[regexp {\\$} $fragment]} {
-	    append line [regsub {\\$} $fragment " "]
-	} else {
-	    append line $fragment
-	    return [list $line $lines]
-	}
+        gets $fd fragment
+        incr lines
+        if {[regexp {\\$} $fragment]} {
+            set blank " "
+            append line [regsub {\\$} $fragment $blank]
+        } else {
+            append line $fragment
+            return [list $line $lines]
+        }
     }
     return [list $line $lines]
 }

--- a/main/db/DBSpectrum.cpp
+++ b/main/db/DBSpectrum.cpp
@@ -28,6 +28,7 @@
 
 
 #include <sstream>
+#include <string>
 #include <stdexcept>
 #include <assert.h>
 
@@ -150,7 +151,7 @@ DBSpectrum::getValues()
     CSqliteStatement fetch(
         m_conn,
         "SELECT xbin, ybin, value FROM spectrum_contents \
-            WHERE spectrum_id = ? ORDER BY id ASC"
+            WHERE spectrum_id = ? "
     );
     fetch.bind(1, m_Info.s_base.s_id);
     while (!(++fetch).atEnd()) {
@@ -217,6 +218,7 @@ DBSpectrum::exists(CSqlite& connection, int sid, const char* name)
  * @param connection   - Database connection object.
  * @param sid          - Save set into which the definition is saved.
  * @param name         - Name of the spectrum, must not exist in saveset.
+ * @param type         - Type of the spectrum to create (stringified).
  * @param parameterNames - Vector of parameter names.
  * @param axes         - Axis definitions.
  * @param datatype     - Channel data type.
@@ -249,6 +251,13 @@ DBSpectrum::create(
     
     validateParameterCount(type, parameterNames.size());
     specinfo.s_parameters = fetchParameters(connection, sid, parameterNames);
+
+    // Generate the X/Y paramter id vectors depending on the
+    // spectrum type:
+
+    std::string strType(type);
+    specinfo.s_xParameters = fetchXParameters(strType, specinfo.s_parameters);
+    specinfo.s_yParameters = fetchYParameters(strType, specinfo.s_parameters);
     
     // Each spectrum type as a specific number of allowed axes:
     
@@ -354,6 +363,65 @@ DBSpectrum::fetchParameters(
     
     return result;
 }
+/**
+ * fetchXParameters
+ *    GIven the spectrum type string and the parameter ids for all parametesr,
+ *    returns a vector of the 'x' parameters.
+ * @param specType - Spectrum type string.
+ * @param ids      - The All parameter ids in -list order.
+ */
+DBSpectrum::Parameters
+DBSpectrum::fetchXParameters(
+    const std::string& specType, const Parameters& ids
+) {
+    Parameters result;
+
+    // All depends on the parameter types:
+
+    if (specType == "1" || specType == "g1" || specType == "g2" || 
+        specType == "s" || specType == "b" || specType == "gs") {
+        result = ids;                                        // They're all X parameters.
+    } else if (specType == "m2" ) {
+        // Even parameters.
+
+        for (auto i = 0; i < ids.size(); i += 2) {
+            result.push_back(ids[i]);
+        }
+    } else if (specType == "gd") {
+        // Don't know how to do in general.
+
+    } else if (specType == "2" || specType == "S") {
+        result.push_back(ids[0]);
+    }
+
+    return result;
+}
+/**
+ * fetchYParmaetrs
+ *    See  above, but the Y parameters are returned.
+*/
+DBSpectrum::Parameters
+DBSpectrum::fetchYParameters(
+    const std::string& specType, const Parameters& ids
+) {
+    Parameters result;
+
+    if (specType == "m2" ) {
+        // odd parameters.
+
+        for (auto i = 1; i < ids.size(); i += 2) {
+            result.push_back(ids[i]);
+        }
+    } else if (specType == "gd") {
+        // Don't know how to do in general.
+
+    } else if (specType == "2" || specType == "S") {
+        result.push_back(ids[1]);
+    }
+
+    return result;
+}
+
 /**
  * validateBaseInfo
  *    Do a few checks:
@@ -529,7 +597,7 @@ DBSpectrum::enterSpectrum(CSqlite& connection, Info& info)
     ++root;                        // insert.
     info.s_base.s_id = root.lastInsertId();
     
-    // add the parameters to spectrum_params
+    // add the parameters to spectrum_params, spectrum_x_params, and spectrum_y_params
     
     CSqliteStatement param (
         connection,
@@ -542,6 +610,31 @@ DBSpectrum::enterSpectrum(CSqlite& connection, Info& info)
         ++param;                     //  insert.
         param.reset();              // prepared for next loop.
     }
+
+    CSqliteStatement xparams (
+        connection,
+        "INSERT INTO spectrum_x_params (spectrum_id, parameter_id) \
+            VALUES (?,?)"
+    );
+    xparams.bind(1, info.s_base.s_id);
+    for (int i =0; i < info.s_xParameters.size(); i++) {
+        xparams.bind(2, info.s_xParameters[i]);
+        ++xparams;
+        xparams.reset();
+    }
+    
+    CSqliteStatement yparams(
+        connection,
+        "INSERT INTO spectrum_y_params (spectrum_id, parameter_id) \
+            VALUES (?,?)"
+    );
+    yparams.bind(1, info.s_base.s_id);
+    for (int i =0; i < info.s_yParameters.size(); i++) {
+        yparams.bind(2, info.s_yParameters[i]);
+        ++yparams;
+        yparams.reset();
+    }
+
     
     // Add the axis definitions (note we need to capture the id of each.)
     
@@ -631,7 +724,7 @@ DBSpectrum::loadInfo(int sid, const char* name)
     
     CSqliteStatement f2(
         m_conn,
-        "SELECT parameter_id FROM spectrum_params WHERE spectrum_id = ?"
+        "SELECT parameter_id FROM spectrum_params WHERE spectrum_id = ? "
     );
     f2.bind(1, m_Info.s_base.s_id);
     while(!(++f2).atEnd()) {
@@ -650,6 +743,29 @@ DBSpectrum::loadInfo(int sid, const char* name)
             << " has no associated parameter records!!!";
         throw std::logic_error(msg.str());
     }
-}
+    // Now x/y parameters, thess _can be empty if we don't know
+    // how to create them (e.g. gd)... These will also fail
+    // for old data bases so ignore exceptions, that will leave the
+    // x/y parameters empty.
 
+    try {
+
+        CSqliteStatement f3(
+            m_conn, 
+            "SELECT parameter_id FROM spectrum_x_params WHERE spectrum_id = ? "
+        );
+        f3.bind(1, m_Info.s_base.s_id);
+        while(! (++f3).atEnd()) {
+            m_Info.s_xParameters.push_back(f3.getInt(0));
+        }
+        CSqliteStatement f4(
+            m_conn, 
+            "SELECT parameter_id FROM spectrum_y_params WHERE spectrum_id = ? "
+        );
+        f4.bind(1, m_Info.s_base.s_id);
+        while(! (++f4).atEnd()) {
+            m_Info.s_yParameters.push_back(f4.getInt(0));
+        }
+    } catch(...) {}
+}
 }               // namespace SpecTclDB

--- a/main/db/DBSpectrum.h
+++ b/main/db/DBSpectrum.h
@@ -94,6 +94,8 @@ namespace SpecTclDB {
         struct Info {
             BaseInfo   s_base;
             Parameters s_parameters;
+            Parameters s_xParameters;
+            Parameters s_yParameters;
             Axes       s_axes;
             Info() {}
             Info(const Info& rhs) {
@@ -106,6 +108,8 @@ namespace SpecTclDB {
             void copyIn(const Info& rhs) {
                 s_base       = rhs.s_base;
                 s_parameters = rhs.s_parameters;
+                s_xParameters = rhs.s_xParameters;
+                s_yParameters = rhs.s_yParameters;
                 s_axes       = rhs.s_axes;
             }
         };
@@ -137,6 +141,9 @@ namespace SpecTclDB {
         public:
             const Info& getInfo() const { return m_Info; }
             std::vector<std::string> getParameterNames();
+            std::vector<std::string> getXParameterNames();
+            std::vector<std::string> getYParameterNames();
+
             void storeValues(const std::vector<ChannelSpec>& data);
             std::vector<ChannelSpec>  getValues();
             bool hasStoredChannels();
@@ -156,6 +163,12 @@ namespace SpecTclDB {
             static Parameters fetchParameters(
                 CSqlite& connection, int sid,
                 const std::vector<const char*>& parameterNames
+            );
+            static Parameters fetchXParameters(
+                const std::string& specType, const Parameters& ids
+            );
+            static Parameters fetchYParameters(
+                const std::string& specType, const Parameters& ids
             );
             static void validateBaseInfo(
                 CSqlite& connection,  const BaseInfo& base

--- a/main/db/DBTcl.cpp
+++ b/main/db/DBTcl.cpp
@@ -1629,6 +1629,8 @@ TclSaveSet::makeSpectrumDict(CTCLObject& obj, DBSpectrum* spec)
     
     auto info   = spec->getInfo();
     auto pNames = spec->getParameterNames();
+    auto xpNames = spec->getXParameterNames();
+    auto ypNames = spec->getYParameterNames();
     
     AddKey(obj, "id", info.s_base.s_id);
     AddKey(obj, "name", info.s_base.s_name.c_str());
@@ -1638,6 +1640,17 @@ TclSaveSet::makeSpectrumDict(CTCLObject& obj, DBSpectrum* spec)
     parameterNames.Bind(*obj.getInterpreter());
     stringVectorToList(*obj.getInterpreter(), parameterNames, pNames);
     AddKey(obj, "parameters", parameterNames);
+
+    CTCLObject xpnames;
+    xpnames.Bind(*obj.getInterpreter());
+    stringVectorToList(*obj.getInterpreter(), xpnames, xpNames);
+    AddKey(obj, "xparameters", xpnames);
+
+    CTCLObject ypnames;
+    ypnames.Bind(*obj.getInterpreter());
+    stringVectorToList(*obj.getInterpreter(), ypnames, ypNames);
+    AddKey(obj, "yparameters", ypnames);
+
     
     CTCLObject axes;
     axes.Bind(*obj.getInterpreter());

--- a/main/db/SpecTclDatabase.cpp
+++ b/main/db/SpecTclDatabase.cpp
@@ -129,6 +129,29 @@ CDatabase::create(const char* database)
         "CREATE INDEX IF NOT EXISTS sparams_spectrum_id \
                 ON spectrum_params (spectrum_id)"
     );
+    // Two tables below added in Issue #91 - distinguish
+    // between X and Y parameters:
+
+    CSqliteStatement::execute(
+        connection,
+        "CREATE TABLE IF NOT EXISTS spectrum_x_params                   \
+            (   id          INTEGER PRIMARY KEY,          \
+                spectrum_id INTEGER NOT NULL,             \
+                parameter_id INTEGER NOT NULL             \
+            )"
+    );
+    CSqliteStatement::execute(
+        connection,
+        "CREATE TABLE IF NOT EXISTS spectrum_y_params             \
+            (   id          INTEGER PRIMARY KEY,    \
+                spectrum_id INTEGER NOT NULL,       \
+                parameter_id INTEGER NOT NULL       \
+            )"
+    );
+
+    // End of Issue #91 additions
+    
+    
     
     // Spectrum contents.
     

--- a/main/db/dbconfig.tcl
+++ b/main/db/dbconfig.tcl
@@ -780,6 +780,12 @@ proc saveConfig {dbconnection name {spectra 0}} {
       
     return $saveset
 }
+##
+# save a configuration using the rustogramer saveset name:
+#
+proc saveForRustogramer {dbconnection} {
+    return [saveConfig $dbconnection rustogramer_gui 0]
+}
 
 
 ##

--- a/main/db/dbconfig.tcl
+++ b/main/db/dbconfig.tcl
@@ -850,6 +850,16 @@ proc restoreConfig {cmd savename {restoreSpectra 0}} {
     $saveset destroy
 }
 ##
+# restoreRustogramer 
+#   Restore the rustogramer_gui saveset.. convenience 
+#   proc for SpecTcl/Rustogramer definition interchanges
+# 
+#  Throws an error if there's no such saveset.
+#
+proc restoreRustogramer {cmd} {
+    return [restoreConfig $cmd rustogramer_gui 0]
+}
+##
 # saveSpectrum
 #   Saves a single spectrum's contents into the specified save set.
 #

--- a/main/db/dbspectests.cpp
+++ b/main/db/dbspectests.cpp
@@ -121,6 +121,18 @@ public:
     
     CPPUNIT_TEST(getpar_1);
     CPPUNIT_TEST(getpar_2);
+
+    CPPUNIT_TEST(getxypar_1);   // 1d spectrum.
+    CPPUNIT_TEST(getxypar_2);   // 2d spectrum.
+    CPPUNIT_TEST(getxypar_3);   // g1
+    CPPUNIT_TEST(getxypar_4);   // g2
+    CPPUNIT_TEST(getxypar_5);   // s
+    CPPUNIT_TEST(getxypar_6);   // b
+    CPPUNIT_TEST(getxypar_7);   // gs
+    CPPUNIT_TEST(getxypar_8);   // m2
+    CPPUNIT_TEST(getxypar_9);   // S 
+    CPPUNIT_TEST(getxypar_10);  // gd
+    
     
     CPPUNIT_TEST(construct_1);
     CPPUNIT_TEST(construct_2);
@@ -185,6 +197,17 @@ protected:
     
     void getpar_1();
     void getpar_2();
+
+    void getxypar_1();
+    void getxypar_2();
+    void getxypar_3();
+    void getxypar_4();
+    void getxypar_5();
+    void getxypar_6();
+    void getxypar_7();
+    void getxypar_8();
+    void getxypar_9();
+    void getxypar_10();
     
     void construct_1();
     void construct_2();
@@ -755,6 +778,201 @@ void dbspectest::getpar_2()
     
     delete pSpec;
     delete pSpec2;
+}
+
+void dbspectest::getxypar_1() {
+    // 1-d spectrum. can give the correct parameter names in X/Y.
+
+    makeStandardParams();
+    std::vector<const char*> pnames = {"param.0"};
+    SpecTclDB::DBSpectrum::Axes axes = {{-1, -10.0, 10.0, 100}};
+    auto pSpec = SpecTclDB::DBSpectrum::create(
+        *m_pDb, m_pSaveSet->getInfo().s_id, "test1d", "1", pnames, axes
+    );
+
+    auto x = pSpec->getXParameterNames();
+    auto y = pSpec->getYParameterNames();
+    EQ(size_t(1), x.size());
+    EQ(std::string("param.0"), x[0]);
+    EQ(size_t(0), y.size());
+
+    delete pSpec;
+}
+void dbspectest::getxypar_2() {
+    // 2-d spectra give x and y parameters:
+
+    makeStandardParams();             //  x            y
+    std::vector<const char*> pnames = {"param.0", "param.1"};
+    SpecTclDB::DBSpectrum::Axes axes = {{-1, -10.0, 10.0, 100}, {-1, 0, 256, 256}};
+
+    auto pSpec = SpecTclDB::DBSpectrum::create(
+        *m_pDb, m_pSaveSet->getInfo().s_id, "test2d", "2", pnames, axes
+    );
+
+    auto x = pSpec->getXParameterNames();
+    auto y = pSpec->getYParameterNames();
+
+    EQ(size_t(1), x.size());
+    EQ(std::string("param.0"), x[0]);
+    EQ(size_t(1), y.size());
+    EQ(std::string("param.1"), y[0]);
+
+    delete pSpec;
+}
+void dbspectest::getxypar_3() {
+    // g1 spectrum is all x parameters:
+    makeStandardParams();
+    std::vector<const char*> pnames = {"param.0", "param.1", "param.2"};
+    SpecTclDB::DBSpectrum::Axes axes = {{-1, -10.0, 10.0, 100}};
+
+    auto pSpec = SpecTclDB::DBSpectrum::create(
+        *m_pDb, m_pSaveSet->getInfo().s_id, "testg1", "g1", pnames, axes
+    );
+    auto x = pSpec->getXParameterNames();
+    auto y = pSpec->getYParameterNames();
+    EQ(pnames.size(), x.size());
+    for ( int i =0; i < pnames.size(); i++) {
+        EQ(std::string(pnames[i]), x[i]);
+    }
+    EQ(size_t(0), y.size());
+
+}
+void dbspectest::getxypar_4() {
+    // g2 are also all x parameters oddly enough since they are not
+    // distinguishable:
+    makeStandardParams();
+    std::vector<const char*> pnames = {"param.0", "param.1", "param.2"};
+    SpecTclDB::DBSpectrum::Axes axes = {{-1, -10.0, 10.0, 100}, {-1, 0.0, 100.0, 100}};
+
+    auto pSpec = SpecTclDB::DBSpectrum::create(
+        *m_pDb, m_pSaveSet->getInfo().s_id, "testg1", "g2", pnames, axes
+    );
+    auto x = pSpec->getXParameterNames();
+    auto y = pSpec->getYParameterNames();
+    EQ(pnames.size(), x.size());
+    for ( int i =0; i < pnames.size(); i++) {
+        EQ(std::string(pnames[i]), x[i]);
+    }
+    EQ(size_t(0), y.size());
+
+
+}
+void dbspectest::getxypar_5() {
+    // Summary spectra are all X parameters:
+    makeStandardParams();
+    std::vector<const char*> pnames = {"param.0", "param.1", "param.2"};
+    SpecTclDB::DBSpectrum::Axes axes = {{-1, -10.0, 10.0, 100}};
+
+    auto pSpec = SpecTclDB::DBSpectrum::create(
+        *m_pDb, m_pSaveSet->getInfo().s_id, "testg1", "s", pnames, axes
+    );
+    auto x = pSpec->getXParameterNames();
+    auto y = pSpec->getYParameterNames();
+    EQ(pnames.size(), x.size());
+    for ( int i =0; i < pnames.size(); i++) {
+        EQ(std::string(pnames[i]), x[i]);
+    }
+    EQ(size_t(0), y.size());
+
+
+}
+void dbspectest::getxypar_6() {
+    // bit mask has a single X parameter.
+
+    makeStandardParams();
+    std::vector<const char*> pnames = {"param.0", };
+    SpecTclDB::DBSpectrum::Axes axes = {{-1, -10.0, 10.0, 100}};
+
+    auto pSpec = SpecTclDB::DBSpectrum::create(
+        *m_pDb, m_pSaveSet->getInfo().s_id, "testb", "b", pnames, axes
+    );
+    auto x = pSpec->getXParameterNames();
+    auto y = pSpec->getYParameterNames();
+    EQ(pnames.size(), x.size());
+    for ( int i =0; i < pnames.size(); i++) {
+        EQ(std::string(pnames[i]), x[i]);
+    }
+    EQ(size_t(0), y.size());
+
+}
+void dbspectest::getxypar_7() {
+    // GS gives nothing sadly.
+
+    makeStandardParams();
+    std::vector<const char*> pnames = {"param.0", "param.1", "param.2", "param.3"};
+    SpecTclDB::DBSpectrum::Axes axes = {{-1, -10.0, 10.0, 100}};
+
+    auto pSpec = SpecTclDB::DBSpectrum::create(
+        *m_pDb, m_pSaveSet->getInfo().s_id, "testb", "gs", pnames, axes
+    );
+    auto x = pSpec->getXParameterNames();
+    auto y = pSpec->getYParameterNames();
+    EQ(size_t(0), x.size());
+    EQ(size_t(0), y.size());
+}
+void dbspectest::getxypar_8() {
+    // m2 - every other param is x every other is y.
+
+    makeStandardParams();        //       x          y          x          y
+    std::vector<const char*> pnames = {"param.0", "param.3", "param.1", "param.2"};
+    SpecTclDB::DBSpectrum::Axes axes = {{-1, -10.0, 10.0, 100}, {-1, 0, 256, 256}};
+
+    auto pSpec =SpecTclDB::DBSpectrum::create(
+        *m_pDb, m_pSaveSet->getInfo().s_id, "testb", "m2", pnames, axes
+    );
+
+    auto x = pSpec->getXParameterNames();
+    auto y = pSpec->getYParameterNames();
+    EQ(pnames.size()/2, x.size());
+    EQ(pnames.size()/2, y.size());
+    for (int i =0; i < pnames.size(); i++) {
+        auto p = std::string(pnames[i]);
+        auto rhs = (i%2 == 0)? x[i/2] : y[i/2];
+        EQ(p, rhs);
+    }
+    delete pSpec;
+
+}
+void dbspectest::getxypar_9() {
+    // Stripchart has one x one y parameter:
+
+    makeStandardParams();
+    std::vector<const char*> pnames = {"param.0", "param.1"};
+    SpecTclDB::DBSpectrum::Axes axes = {{-1, 0, 100, 100}};
+
+    auto pspec = SpecTclDB::DBSpectrum::create(
+        *m_pDb, m_pSaveSet->getInfo().s_id, "testb", "S", pnames, axes
+    );
+
+    auto x = pspec->getXParameterNames();
+    auto y = pspec->getYParameterNames();
+
+    EQ(size_t(1), x.size());
+    EQ(std::string(pnames[0]), x[0]);
+
+    EQ(size_t(1), y.size());
+    EQ(std::string(pnames[1]), y[0]);
+
+    delete pspec;
+}
+void dbspectest::getxypar_10() {
+    // Gamma deluxe also can't give parameters.
+
+    makeStandardParams();
+    std::vector<const char*> pnames = {"param.0", "param.3", "param.1", "param.2"};
+    SpecTclDB::DBSpectrum::Axes axes = {{-1, -10.0, 10.0, 100}, {-1, 0, 256, 256}};
+
+    auto pSpec =SpecTclDB::DBSpectrum::create(
+        *m_pDb, m_pSaveSet->getInfo().s_id, "testb", "gd", pnames, axes
+    );
+
+    auto x = pSpec->getXParameterNames();
+    auto y = pSpec->getYParameterNames();
+
+    EQ(size_t(0), x.size());
+    EQ(size_t(0), y.size());
+    delete pSpec;
+    
 }
 
 void dbspectest::construct_1()

--- a/main/db/dbtcl.test
+++ b/main/db/dbtcl.test
@@ -1030,8 +1030,9 @@ tcltest::test  dbtcl_findspec_1 {Find a 1d spectrum} \
     if {[info exists result]} { unset result}
     $svcmd findSpectrum raw.1
 } -result [dict create \
-id 1 name raw.1 type 1 parameters [list param.0] \
-         axes [list [dict create low 0.0 high 4095.0 bins 4096]] datatype long \
+    id 1 name raw.1 type 1 parameters [list param.0] \
+    xparameters [list param.0] yparameters [list]\
+    axes [list [dict create low 0.0 high 4095.0 bins 4096]] datatype long \
 ]
 
 tcltest::test dbtcl_findspec_2 {find 2-d spectrum} \
@@ -1059,6 +1060,7 @@ tcltest::test dbtcl_findspec_2 {find 2-d spectrum} \
     $svcmd findSpectrum raw.2
 } -result [dict create \
     id 2 name raw.2 type 2 parameters [list param.1 param.2] \
+    xparameters [list param.1] yparameters [list param.2] \
     axes [list [dict create low 0.0 high 1024.0 bins 512] \
           [dict create low -10.0 high 10.0 bins 100]]  datatype long     \
 ]
@@ -1187,10 +1189,12 @@ tcltest::test dbtcl_listspec_2 {list a couple spectra} \
 } -result [list                                    \
  [dict create \
 id 1 name raw.1 type 1 parameters [list param.0] \
+    xparameters [list param.0] yparameters [list] \
          axes [list [dict create low 0.0 high 4095.0 bins 4096]] datatype long \
 ] \
  [dict create \
     id 2 name raw.2 type 2 parameters [list param.1 param.2] \
+    xparameters [list param.1] yparameters [list param.2] \
     axes [list [dict create low 0.0 high 1024.0 bins 512] \
           [dict create low -10.0 high 10.0 bins 100]]  datatype long]     \
 ]

--- a/main/db/names.test
+++ b/main/db/names.test
@@ -185,7 +185,12 @@ tcltest::test create_2 {test double creation} \
 -cleanup {rmdb}                       \
 -body {
     DBTcl create $database;             # Should work fine given create_2
-    catch {DBTcl create $database}
+    if {[catch {DBTcl create $database} msg]}  {
+        set result $msg
+    } else {
+        set result 0
+    }
+    set result
 } -result 0
 
 

--- a/main/db/specdbtests.cpp
+++ b/main/db/specdbtests.cpp
@@ -44,6 +44,8 @@ static const char* expectedTables[] {
         "spectrum_defs",
         "axis_defs",
         "spectrum_params",
+        "spectrum_x_params",
+        "spectrum_y_params",
         "spectrum_contents",
         "gate_defs",
         "gate_points",


### PR DESCRIPTION
* SpecTcl's database scheme was enlarged to include the x/y parameter tables in rustogramer databases.
* Save/restore were modified to use these tables (if they exist for restore).
* Some interesting diddles were done to actually be able to use rustogramer written database:
    * f64 data type -> long
    * the extra axis definition written for e..g. summary spectra is discarded.
*  The Tree GUI was modified so the File->Save and File->Restore methods allow you to read/write database files.

A side issue was also fixed - given the resolution of Issue #95 the TestDataSource was modified to produce ring items as that's the default/initial buffer format and there's no way to modify it for the initiall attached data source.