### PR TITLE
DDAS skel updates, minor fixes

### DIFF
--- a/main/Core/Makefile.am
+++ b/main/Core/Makefile.am
@@ -379,7 +379,6 @@ libTclGrammerApp_la_SOURCES = $(DecoderRing_SRC) \
 # Removed -I@top_srcdir@/Tape
 
 libTclGrammerApp_la_CXXFLAGS = @UFMT_CPPFLAGS@ -I@top_srcdir@/Utility \
-			-I/mnt/misc/sw/x86_64/Debian/8/root/gnu/6.08.00/include \
 				-I@top_srcdir@/Display \
 				 -I@top_srcdir@/factories \
 				 -I@top_srcdir@/Tape \

--- a/main/configure.ac
+++ b/main/configure.ac
@@ -836,7 +836,7 @@ AC_SUBST(UFMT_LDFLAGS)
 # We no longer look for Ryan's deb to be installed as that ship sailed
 # a long time ago:
 
-AC_CHECK_FILE([${srcdir}/tibtcl/configure.ac], [TCLPLUS_INCORP="1"], [TCLPLUS_INCORP="0"])
+AC_CHECK_FILE([${srcdir}/libtcl/configure.ac], [TCLPLUS_INCORP="1"], [TCLPLUS_INCORP="0"])
 if test "${TCLPLUS_INCORP}" = "0"
 then
   AC_MSG_NOTICE([Incorporating tcl++ version ${TCLPLUS_VERSION} for you])

--- a/main/ddas/src/Makefile.am
+++ b/main/ddas/src/Makefile.am
@@ -1,18 +1,11 @@
-
-FILES =MyParameters.h \
-				MyParameters.cpp \
-				MyParameterMapper.h \
-				MyParameterMapper.cpp \
-				MySpecTclApp.h \
-				MySpecTclApp.cpp
+FILES = MyCalibrator.cpp MyCalibrator.h MyParameterMapper.cpp MyParameterMapper.h MyParameters.cpp MyParameters.h MySpecTclApp.cpp MySpecTclApp.h SpecTclInit.tcl SpecTclRC.tcl
 
 DESTDIR = @prefix@/DDASSkel
-
 
 install-data-local:
 	${mkinstalldirs} ${DESTDIR}
 	for file in ${FILES} ; do ${INSTALL_DATA} @srcdir@/$$file ${DESTDIR} ; done 
 	${INSTALL_DATA} Makefile_user ${DESTDIR}/Makefile
 
-EXTRA_DIST=$(FILES)
+EXTRA_DIST = $(FILES)
 

--- a/main/ddas/src/Makefile_user.in
+++ b/main/ddas/src/Makefile_user.in
@@ -1,32 +1,29 @@
-INSTDIR=@prefix@
-# Skeleton makefile for 3.1
+# Skeleton Makefile for SpecTcl 5.xx
 
+INSTDIR=/usr/opt/spectcl/5.14-000
 include $(INSTDIR)/etc/SpecTcl_Makefile.include
 
-#  If you have any switches that need to be added to the default c++ compilation
+# If you have any switches that need to be added to the default c++ compilation
 # rules, add them to the definition below:
 
-USERCXXFLAGS=-std=c++11 
+USERCXXFLAGS=-std=c++14
 
-#  If you have any switches you need to add to the default c compilation rules,
-#  add them to the defintion below:
+# If you have any switches you need to add to the default c compilation rules,
+# add them to the defintion below:
 
 USERCCFLAGS=$(USERCXXFLAGS)
 
-#  If you have any switches you need to add to the link add them below:
+# If you have any switches you need to add to the link add them below:
 
 USERLDFLAGS=-lDDASUnpacker 
 
-#
-#   Append your objects to the definitions below:
-#
+# Append your objects to the definitions below:
 
-OBJECTS=MySpecTclApp.o MyParameters.o MyParameterMapper.o
+OBJECTS=MySpecTclApp.o MyParameters.o MyParameterMapper.o MyCalibrator.o
 
 #
-#  Finally the makefile targets.
+# Finally the Makefile targets:
 #
-
 
 SpecTcl: $(OBJECTS)
 	$(CXXLD)  -o SpecTcl $(OBJECTS) $(USERLDFLAGS) \

--- a/main/ddas/src/MyCalibrator.cpp
+++ b/main/ddas/src/MyCalibrator.cpp
@@ -1,0 +1,39 @@
+#include "MyCalibrator.h"
+
+#include <random>
+
+#include <config.h>
+#include "MyParameters.h"
+
+//________________________________________________________________________
+// Initialize our parameters and variables. 
+//
+MyCalibrator::MyCalibrator(MyParameters& rParams) :
+    m_params(rParams),
+    m_ecal("cal", 32768, 0, 32767, "a.u", 16, 0),
+    m_slope("slope", 0.5, "", 16, 0),
+    m_offset("offset", 1000., "", 16, 0)
+{}
+
+//________________________________________________________________________
+// Each physics event is processed here.
+//
+Bool_t
+MyCalibrator::operator()(
+    Address_t pEvent, CEvent& rEvent,
+    CAnalyzer& rAnalyzer, CBufferDecoder& rDecoder
+    )
+{
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+    static std::uniform_real_distribution<> dist(0., 1.);
+    
+    for (int i = 0; i < 16; i++) {
+	if (m_params.chan[i].energy.isValid()) {
+	    m_ecal[i] = m_slope[i]*m_params.chan[i].energy
+		+ m_offset[i] + dist(gen);
+	}
+    }
+
+    return kfTRUE;
+}

--- a/main/ddas/src/MyCalibrator.h
+++ b/main/ddas/src/MyCalibrator.h
@@ -1,0 +1,47 @@
+#ifndef MYCALIBRATOR_H
+#define MYCALIBRATOR_H
+
+#include <EventProcessor.h>
+#include <TreeParameter.h>
+
+class MyParameters;
+
+//________________________________________________________________________
+// Calibrated parameters using TreeParameters.
+//
+class MyCalibrator : public CEventProcessor
+{
+private:
+    MyParameters&       m_params; // Raw parameters.
+    CTreeParameterArray m_ecal;   // Calibrated energy parameters.
+    CTreeVariableArray  m_slope;  // Slope for linear calibration.
+    CTreeVariableArray  m_offset; // Offset for linear calibration.
+
+public:
+    /**
+     * @brief Construct using MyParameters.
+     *
+     * @param rParams References the raw parameter struct.
+     */
+    MyCalibrator(MyParameters& rParams);
+
+    /**
+     * @brief Called for each physics event seen by the event processor. 
+     *
+     * @param pEvent Pointer to the raw data.
+     * @param rEvent Array-like storage for parameter values created by the 
+     *   event-processing pipeline.
+     * @param rAnalyzer Analyzer object (rarely used). 
+     * @param rDecoder Buffer decoder object (rarely used).
+     * 
+     * @return Bool indicating status. False will terminate the event 
+     *   processing pipeline.
+     */
+    Bool_t operator()(
+	const Address_t pEvent, CEvent& rEvent,
+	CAnalyzer& rAnalyzer, CBufferDecoder& rDecoder
+	);
+
+};
+
+#endif

--- a/main/ddas/src/MyParameterMapper.cpp
+++ b/main/ddas/src/MyParameterMapper.cpp
@@ -1,56 +1,61 @@
-
 #include "MyParameterMapper.h"
+
 #include "MyParameters.h"
 
-// Make it possible to write DDASHit instead of DAQ::DDAS::DDASHit.
+// Make it possible to write DDASHit instead of DAQ::DDAS::DDASHit:
 using DAQ::DDAS::DDASHit;
 
-////
+//________________________________________________________________________
+// Initialize the parameters and channel map.
 //
-MyParameterMapper::MyParameterMapper(MyParameters& params) 
-  : m_params(params),
-   m_chanMap()
+// To add additional crates:
+//     m_chanMap[crateID] = startIndex;
+//
+// A full crate of Pixie-16 digitizers contains 208 channels. For a second
+// crate, starting at channel 208, one would add the fllowing line:
+//     m_chanMap[1] = 208;
+//
+MyParameterMapper::MyParameterMapper(MyParameters& params) :
+    m_params(params), m_chanMap()
 {
-  // crate 0 has 2 modules and thus accounts for 32 channels and
-  // crate 1 doesnt exist. This means that the first channel index
-  // of crate 2 is 32.
-  m_chanMap[0] = 0;
-  m_chanMap[2] = 32;
+    // Crate 0 has one module which starts at global channel index 0:
+    m_chanMap[0] = 0;
 }
 
+//________________________________________________________________________
+// 
 void MyParameterMapper::mapToParameters(const std::vector<DDASHit>& channelData,
                                         CEvent& rEvent)
 {
-  size_t nHits = channelData.size();
+    size_t nHits = channelData.size();
 
-  // assign number of hits as event multiplicity
-  m_params.multiplicity = nHits;
+    // Assign number of hits as event multiplicity:
+    m_params.multiplicity = nHits;
 
-  // loop over all hits in event
-  for (size_t i=0; i<nHits; ++i) {
-
-    // convenience variable declared to refer to the i^th hit
-    auto& hit = channelData[i];
-
-    // Use the crate, slot, and channel to figure out the global
-    // channel index.
-    int globalChanIdx = computeGlobalIndex(hit);
-
-    // Assign values to appropriate channel
-    m_params.chan[globalChanIdx].energy    = hit.GetEnergy();
-    m_params.chan[globalChanIdx].timestamp = hit.GetTime();
-
-  }
-
+    // Loop over all hits in event:
+    for (size_t i = 0; i < nHits; i++) {
+	// Convenience variable declared to refer to the i^th hit
+	auto& hit = channelData[i];
+    
+	// Use the crate, slot, and channel to figure out the global index:
+	int globalChanIdx = computeGlobalIndex(hit);
+    
+	// Assign values to appropriate channel:
+	m_params.chan[globalChanIdx].energy    = hit.GetEnergy();
+	m_params.chan[globalChanIdx].timestamp = hit.GetTime();
+    }
+  
 }
 
+//________________________________________________________________________
+// 
 int MyParameterMapper::computeGlobalIndex(const DDASHit& hit) 
 {
-  int crateId = hit.GetCrateID();
-  int slotIdx = hit.GetSlotID()-2;
-  int chanIdx = hit.GetChannelID();
+    int crateId = hit.GetCrateID();
+    int slotIdx = hit.GetSlotID() - 2; // First module is in slot 2.
+    int chanIdx = hit.GetChannelID();
 
-  const int nChanPerSlot = 16;
+    const int nChanPerSlot = 16;
 
-  return m_chanMap[crateId] + slotIdx*nChanPerSlot + chanIdx;
+    return m_chanMap[crateId] + slotIdx*nChanPerSlot + chanIdx;
 }

--- a/main/ddas/src/MyParameterMapper.h
+++ b/main/ddas/src/MyParameterMapper.h
@@ -1,5 +1,3 @@
-
-
 #ifndef MYPARAMETERMAPPER_H
 #define MYPARAMETERMAPPER_H
 
@@ -7,40 +5,48 @@
 
 #include <map>
 
-// SpecTcl event, we don't use it 
-class CEvent; 
+class CEvent;       // SpecTcl event, we don't use it.
+class MyParameters; // The strucutre of tree parameters.
 
-// The strucutre of tree parameters
-class MyParameters;
-
-
+//________________________________________________________________________
 // Class responsible for mapping DDAS hit data to SpecTcl TreeParameters
 //
 // It operates on a MyParameters structure containing TreeParameters but 
 // does not own it.
+//
 class MyParameterMapper : public DAQ::DDAS::CParameterMapper
 {
-  private:
-    MyParameters& m_params;           // reference to the tree parameter structure
-    std::map<int, int> m_chanMap;     // global channel index for crates
+private:
+    MyParameters&      m_params;  // Reference to the tree parameter structure.
+    std::map<int, int> m_chanMap; // Global channel index for crates.
 
-  public:
-    // Constructor.
-    //
-    //  \param params   the data structure
+public:
+    /**
+     * @brief Constructor.
+     *
+     * @param params The data structure.
+     */    
     MyParameterMapper(MyParameters& params);
-
-    // Map raw hit data to TreeParameters
-    //
-    // \param channelData   the hit data
-    // \param rEvent        the SpecTcl event
-    virtual void mapToParameters(const std::vector<DAQ::DDAS::DDASHit>& channelData, 
-                                  CEvent& rEvent);
-
-    // Compute channel index from crate, slot, and channel information
-    //
-    // \param hit   the ddas hit
+    
+    /**
+     * @brief Map raw hit data to tree parameters.
+     *
+     * @param channelData The hit data.
+     * @param rEvent      The SpecTcl event.
+     */
+    virtual void mapToParameters(
+	const std::vector<DAQ::DDAS::DDASHit>& channelData, CEvent& rEvent
+	);
+    
+    /**
+     * @brief Compute channel index from crate, slot, and channel information.
+     * 
+     * @param hit The hit data.
+     * 
+     * @return The global channel index.
+     */ 
     int computeGlobalIndex(const DAQ::DDAS::DDASHit& hit);
 };
+
 #endif
 

--- a/main/ddas/src/MyParameters.cpp
+++ b/main/ddas/src/MyParameters.cpp
@@ -1,35 +1,29 @@
-
 #include "MyParameters.h"
 
-using namespace std;
-
-////
+//________________________________________________________________________
+// Initialize the ChannelData
 //
-// 
-void ChannelData::Initialize(string name) {
-  // energy : 4096 channels between 0 and 4096
-  energy.Initialize(name + ".energy", 4096, 0, 4095, "a.u.");
+void ChannelData::Initialize(std::string name) {
+    // Energy: 32768 channels between 0 and 32767
+    energy.Initialize(name + ".energy", 32768, 0, 32767, "a.u.");
 
-  // timestamp : 
-  timestamp.Initialize(name + ".timestamp", 48, 0, pow(2., 48)-1, 
-                       "ns",true);
+    // Timestamp: 64 bits with 2^64-1 ns per bin starting at 0
+    timestamp.Initialize(
+	name + ".timestamp", 64, 0, std::pow(2,64)-1, "ns", true
+	);
 }
 
-////
+//________________________________________________________________________
+// Initialize MyParameters. Calls ChannelData::Initialize() to initialize
+// ChannelData for each channel in the system.
 //
-//
-MyParameters::MyParameters(string name) 
+MyParameters::MyParameters(std::string name) 
 {
-  // create the 48 channels 
-  for (size_t i=0; i<48; ++i) {
-    chan[i].Initialize(name + to_string(i));
-  }
+    // Create the 16 channels 
+    for (size_t i = 0; i < 16; i++) {
+	chan[i].Initialize(name + std::to_string(i));
+    }
 
-  // initialize the multiplicity
-  //  - 32 bins between -0.5 to 31.5.
-  multiplicity.Initialize(name + ".mult", 32, -0.5, 30.5, "a.u.");
+    // Initialize the multiplicity: 32 bins between 0 and 31
+    multiplicity.Initialize(name + ".mult", 32, 0, 31, "a.u.");
 }
-
-
-
-

--- a/main/ddas/src/MyParameters.h
+++ b/main/ddas/src/MyParameters.h
@@ -1,12 +1,12 @@
-
 #ifndef MYPARAMETERS_H
 #define MYPARAMETERS_H
 
-#include <config.h>
-#include <TreeParameter.h>
 #include <string>
 
+#include <config.h>
+#include <TreeParameter.h>
 
+//________________________________________________________________________
 // The tree-like structure of data will be :
 // 
 //  MyParameters
@@ -21,49 +21,52 @@
 //  |   +-- energy
 //  |   \-- timestamp
 //  |
-//  ... (45 more channel data objects)
+//  ... (13 more channel data objects)
 //  |
-//  \-- ChannelData (chan[47])
+//  \-- ChannelData (chan[15])
 //      +-- energy
 //      \-- timestamp
 //
-//
 struct ChannelData {
+    
+    CTreeParameter energy;
+    CTreeParameter timestamp;
 
-  CTreeParameter energy;
-  CTreeParameter timestamp;
-
-  // Initialize the TreeParameters
-  //
-  // We will create TreeParameters with names associated with
-  // the name passed in. For example, if name = "rawdata", then 
-  // we will create TreeParameters with names rawdata.energy and
-  // rawdata.timestamp.
-  //
-  // \param name  name of parent in tree structure
-  void Initialize(std::string name);
+    /**
+     * @brief Initialize the TreeParameters
+     * 
+     * @details
+     * We will create TreeParameters with names associated with the name 
+     * passed in. For example, if name = "rawdata", then we will create 
+     * TreeParameters with names rawdata.energy and rawdata.timestamp.
+     *
+     * @param name Name of parent in tree structure.
+     */
+    void Initialize(std::string name);
 };
 
-//____________________________________________________________
+//________________________________________________________________________
 // Struct for top-level events
 // 
-//  This contains 48 channels of data because we have 3 modules
-//  in our system, each with 16 channels a piece.
+//  This contains 16 channels of data because we have 1 16-channel module
+//  in our system. We also want to keep some information for the number of
+//  DDAS hits per event (i.e. the multiplicity).
 //
-//  We also want to keep some information for the number of ddas hits
-//  per event (i.e. the multiplicity)
 struct MyParameters {
+    
+    ChannelData    chan[16];
+    CTreeParameter multiplicity;
 
-  ChannelData          chan[48];
-  CTreeParameter   multiplicity;
-
-  // Constructor
-  //
-  // This is the root of the tree structure. The name of this
-  // will be used to name the branches of the tree.
-  //
-  // \param name  name of root
-  MyParameters(std::string name);
+    /**
+     * @brief Constructor.
+     * 
+     * @details
+     * This is the root of the tree structure. The name of this will be used 
+     * to name branches of the tree.
+     *
+     * @param name Name of root.
+     */
+    MyParameters(std::string name);
 };
 
 #endif

--- a/main/ddas/src/MySpecTclApp.cpp
+++ b/main/ddas/src/MySpecTclApp.cpp
@@ -1,59 +1,69 @@
+#include "MySpecTclApp.h"
 
 #include <config.h>
-#include "MySpecTclApp.h"
 #include "DDASBuiltUnpacker.h"
 #include "MyParameterMapper.h"
 #include "MyParameters.h"
+#include "MyCalibrator.h"
 
+using namespace DAQ::DDAS;
+
+//________________________________________________________________________
 // Create the parameter tree
+//
 MyParameters params("raw");
 
+//________________________________________________________________________
 // Create a MyParameterMapper and pass it to the unpacker. The unpacker
-// will take ownership of this object.
-DAQ::DDAS::CDDASBuiltUnpacker Stage1( {0, 1, 2 }, *(new MyParameterMapper(params)));
+// will take ownership of this object. The mapper maintains a reference
+// to the raw parameters but does not own them.
+//
+static CDDASBuiltUnpacker unpacker({0}, *(new MyParameterMapper(params)));
 
-void 
+//________________________________________________________________________
+// Create event processors implementing our custom code. The calibrator
+// maintains a reference to the raw parameters but does not own them.
+//
+static MyCalibrator calibrator(params);
+
+//________________________________________________________________________
+void
 CMySpecTclApp::CreateAnalysisPipeline(CAnalyzer& rAnalyzer)  
-{ 
-    RegisterEventProcessor(Stage1, "Raw");
-}  
+{   
+    RegisterEventProcessor(unpacker, "Raw");
+    RegisterEventProcessor(calibrator, "Cal");
+}
 
+//________________________________________________________________________
 // Constructors, destructors and other replacements for compiler cannonicals:
 
 CMySpecTclApp::CMySpecTclApp ()
-{   
-} 
+{} 
 
-	// Destructor:
+// Destructor:
+CMySpecTclApp::~CMySpecTclApp ( )
+{}
 
- CMySpecTclApp::~CMySpecTclApp ( )
-{
-} 
-
-
+//________________________________________________________________________
 // Functions for class CMySpecTclApp
 
-
-
 //  Function: 	
-//    void BindTCLVariables(CTCLInterpreter& rInterp) 
+//     void BindTCLVariables(CTCLInterpreter& rInterp) 
 //  Operation Type:
 //     override
 /*  
-Purpose: 	
+    Purpose: 	
 
- Add code to this function to bind any TCL variable to
- the SpecTcl interpreter.  Note that at this time,
- variables have not yet been necessarily created so you
- can do Set but not necessarily Get operations.
-
-
+    Add code to this function to bind any TCL variable to
+    the SpecTcl interpreter.  Note that at this time,
+    variables have not yet been necessarily created so you
+    can do Set but not necessarily Get operations.
 
 */
 void 
 CMySpecTclApp::BindTCLVariables(CTCLInterpreter& rInterp)  
 { 
-  CTclGrammerApp::BindTCLVariables(rInterp);
+    CTclGrammerApp::BindTCLVariables(rInterp);
 }  
 
 //  Function: 	
@@ -61,19 +71,20 @@ CMySpecTclApp::BindTCLVariables(CTCLInterpreter& rInterp)
 //  Operation Type:
 //     Override
 /*  
-Purpose: 	
+    Purpose: 	
 
-Add code here to source additional variable setting
-scripts.  At this time the entire SpecTcl/Tk infrastructure
-is not yet set up.  Scripts run at this stage can only run
-basic Tcl/Tk commands, and not SpecTcl extensions.
-Typically, this might be used to set a bunch of initial values
-for variables which were bound in BindTCLVariables.
+    Add code here to source additional variable setting
+    scripts.  At this time the entire SpecTcl/Tk infrastructure
+    is not yet set up. Scripts run at this stage can only run
+    basic Tcl/Tk commands, and not SpecTcl extensions.
+    Typically, this might be used to set a bunch of initial values
+    for variables which were bound in BindTCLVariables.
 
 */
 void 
 CMySpecTclApp::SourceLimitScripts(CTCLInterpreter& rInterpreter)  
-{ CTclGrammerApp::SourceLimitScripts(rInterpreter);
+{
+    CTclGrammerApp::SourceLimitScripts(rInterpreter);
 }  
 
 //  Function: 	
@@ -81,17 +92,18 @@ CMySpecTclApp::SourceLimitScripts(CTCLInterpreter& rInterpreter)
 //  Operation Type:
 //     overide
 /*  
-Purpose: 	
+    Purpose: 	
 
-Called after BindVariables and SourceLimitScripts.
-This function can be used to fetch values of bound Tcl
-variables which were modified/set by the limit scripts to
-update program default values. 
+    Called after BindVariables and SourceLimitScripts.
+    This function can be used to fetch values of bound Tcl
+    variables which were modified/set by the limit scripts to
+    update program default values. 
 
 */
 void 
 CMySpecTclApp::SetLimits()  
-{ CTclGrammerApp::SetLimits();
+{
+    CTclGrammerApp::SetLimits();
 }  
 
 //  Function: 	
@@ -99,18 +111,19 @@ CMySpecTclApp::SetLimits()
 //  Operation Type:
 //     Override
 /*  
-Purpose: 	
+    Purpose: 	
 
-Creates the histogramming data sink.  If you want to override
-this in general you probably won't make use of the actual
-base class function.  You might, however extend this by 
-defining a base set of parameters and histograms from within
-the program.
+    Creates the histogramming data sink. If you want to override
+    this in general you probably won't make use of the actual
+    base class function.  You might, however extend this by 
+    defining a base set of parameters and histograms from within
+    the program.
 
 */
 void 
 CMySpecTclApp::CreateHistogrammer()  
-{ CTclGrammerApp::CreateHistogrammer();
+{
+    CTclGrammerApp::CreateHistogrammer();
 }  
 
 //  Function: 	
@@ -118,17 +131,18 @@ CMySpecTclApp::CreateHistogrammer()
 //  Operation Type:
 //     Override.
 /*  
-Purpose: 	
+    Purpose: 	
 
-Select a displayer object and link it to the
-histogrammer.  The default code will link Xamine
-to the displayer, and set up the Xamine event handler
-to deal with gate objects accepted by Xamine interaction.
+    Select a displayer object and link it to the
+    histogrammer. The default code will link Xamine
+    to the displayer, and set up the Xamine event handler
+    to deal with gate objects accepted by Xamine interaction.
 
 */
 void 
 CMySpecTclApp::SelectDisplayer(UInt_t nDisplaySize, CHistogrammer& rHistogrammer)  
-{ CTclGrammerApp::SelectDisplayer(nDisplaySize, rHistogrammer);
+{
+    CTclGrammerApp::SelectDisplayer(nDisplaySize, rHistogrammer);
 }  
 
 //  Function: 	
@@ -136,20 +150,21 @@ CMySpecTclApp::SelectDisplayer(UInt_t nDisplaySize, CHistogrammer& rHistogrammer
 //  Operation Type:
 //     Override
 /*  
-Purpose: 	
+    Purpose: 	
 
- Allows you to set up a test data source.  At
-present, SpecTcl must have a data source of some sort
-connected to it... The default test data source produces a 
-fixed length event where all parameters are selected from
-a gaussian distribution.  If you can figure out how to do it,
-you can setup your own data source... as long as you don't
-start analysis, the default one is harmless.
+    Allows you to set up a test data source.  At
+    present, SpecTcl must have a data source of some sort
+    connected to it... The default test data source produces a 
+    fixed length event where all parameters are selected from
+    a gaussian distribution. If you can figure out how to do it,
+    you can setup your own data source... as long as you don't
+    start analysis, the default one is harmless.
 
 */
 void 
 CMySpecTclApp::SetupTestDataSource()  
-{ CTclGrammerApp::SetupTestDataSource();
+{
+    CTclGrammerApp::SetupTestDataSource();
 }  
 
 //  Function: 	
@@ -157,19 +172,21 @@ CMySpecTclApp::SetupTestDataSource()
 //  Operation Type:
 //     Override
 /*  
-Purpose: 	
+    Purpose: 	
 
-Creates an analyzer.  The Analyzer is connected to the data
-source which supplies buffers.  Connected to the analyzer is a
-buffer decoder and an event unpacker.  The event unpacker is 
-the main experiment dependent chunk of code, not the analyzer.
-The analyzer constructed by the base class is a CTclAnalyzer instance.
-This is an analyzer which maintains statistics about itself in Tcl Variables.
+    Creates an analyzer. The Analyzer is connected to the data
+    source which supplies buffers.  Connected to the analyzer is a
+    buffer decoder and an event unpacker. The event unpacker is 
+    the main experiment dependent chunk of code, not the analyzer.
+    The analyzer constructed by the base class is a CTclAnalyzer instance.
+    This is an analyzer which maintains statistics about itself in Tcl 
+    variables.
 
 */
 void 
 CMySpecTclApp::CreateAnalyzer(CEventSink* pSink)  
-{ CTclGrammerApp::CreateAnalyzer(pSink);
+{
+    CTclGrammerApp::CreateAnalyzer(pSink);
 }  
 
 //  Function: 	
@@ -177,18 +194,19 @@ CMySpecTclApp::CreateAnalyzer(CEventSink* pSink)
 //  Operation Type:
 //     Override
 /*  
-Purpose: 	
+    Purpose: 	
 
-  Selects a decoder and attaches it to the analyzer.
-A decoder is responsible for knowing the overall structure of
-a buffer produced by a data analysis system.  The default code
-constructs a CNSCLBufferDecoder object which knows the format
-of NSCL buffers.
+    Selects a decoder and attaches it to the analyzer.
+    A decoder is responsible for knowing the overall structure of
+    a buffer produced by a data analysis system. The default code
+    constructs a CNSCLBufferDecoder object which knows the format
+    of NSCL buffers.
 
 */
 void 
 CMySpecTclApp::SelectDecoder(CAnalyzer& rAnalyzer)  
-{ CTclGrammerApp::SelectDecoder(rAnalyzer);
+{
+    CTclGrammerApp::SelectDecoder(rAnalyzer);
 }  
 
 
@@ -198,18 +216,19 @@ CMySpecTclApp::SelectDecoder(CAnalyzer& rAnalyzer)
 //  Operation Type:
 //     Override
 /*  
-Purpose: 	
+    Purpose: 	
 
-This function adds commands to extend Tcl/Tk/SpecTcl.
-The base class function registers the standard SpecTcl command
-packages.  Your commands can be registered at this point.
-Do not remove the sample code or the SpecTcl commands will
-not get registered.
+    This function adds commands to extend Tcl/Tk/SpecTcl.
+    The base class function registers the standard SpecTcl command
+    packages. Your commands can be registered at this point.
+    Do not remove the sample code or the SpecTcl commands will
+    not get registered.
 
 */
 void 
 CMySpecTclApp::AddCommands(CTCLInterpreter& rInterp)  
-{ CTclGrammerApp::AddCommands(rInterp);
+{
+    CTclGrammerApp::AddCommands(rInterp);
 }  
 
 //  Function: 	
@@ -217,20 +236,21 @@ CMySpecTclApp::AddCommands(CTCLInterpreter& rInterp)
 //  Operation Type:
 //     Override.
 /*  
-Purpose: 	
+    Purpose: 	
 
-  Sets up the Run control object.  The run control object
-is responsible for interacting with the underlying operating system
-and programming framework to route data from the data source to 
-the SpecTcl analyzer.  The base class object instantiates a 
-CTKRunControl object.  This object uses fd waiting within the 
-Tcl/TK event processing loop framework to dispatch buffers for
-processing as they become available.
+    Sets up the Run control object. The run control object
+    is responsible for interacting with the underlying operating system
+    and programming framework to route data from the data source to 
+    the SpecTcl analyzer. The base class object instantiates a 
+    CTKRunControl object. This object uses fd waiting within the 
+    Tcl/TK event processing loop framework to dispatch buffers for
+    processing as they become available.
 
 */
 void 
 CMySpecTclApp::SetupRunControl()  
-{ CTclGrammerApp::SetupRunControl();
+{
+    CTclGrammerApp::SetupRunControl();
 }  
 
 //  Function: 	
@@ -238,17 +258,18 @@ CMySpecTclApp::SetupRunControl()
 //  Operation Type:
 //     Override
 /*  
-Purpose: 	
+    Purpose: 	
 
-  This function allows the user to source scripts
-which have access to the full Tcl/Tk/SpecTcl
-command set along with whatever extensions have been
-added by the user in AddCommands.  
+    This function allows the user to source scripts
+    which have access to the full Tcl/Tk/SpecTcl
+    command set along with whatever extensions have been
+    added by the user in AddCommands.  
 
 */
 void 
 CMySpecTclApp::SourceFunctionalScripts(CTCLInterpreter& rInterp)  
-{ CTclGrammerApp::SourceFunctionalScripts(rInterp);
+{
+    CTclGrammerApp::SourceFunctionalScripts(rInterp);
 }  
 
 //  Function: 	
@@ -256,24 +277,22 @@ CMySpecTclApp::SourceFunctionalScripts(CTCLInterpreter& rInterp)
 //  Operation Type:
 //     Override.
 /*  
-Purpose: 	
+    Purpose: 	
 
-  Entered at Tcl/Tk initialization time (think of this
-as the entry point of the SpecTcl program).  The base
-class default  implementation calls the member functions
-of this class in an appropriate order.  It's possible for the user
-to extend this functionality by adding code to this function.
+    Entered at Tcl/Tk initialization time (think of this
+    as the entry point of the SpecTcl program). The base
+    class default  implementation calls the member functions
+    of this class in an appropriate order. It's possible for the user
+    to extend this functionality by adding code to this function.
 
 */
 int 
 CMySpecTclApp::operator()()  
 { 
-  return CTclGrammerApp::operator()();
+    return CTclGrammerApp::operator()();
 }
 
 CMySpecTclApp   myApp;
-
-
 
 #ifdef SPECTCL_5_INIT
 CTclGrammerApp* CTclGrammerApp::m_pInstance = &myApp;

--- a/main/ddas/src/MySpecTclApp.h
+++ b/main/ddas/src/MySpecTclApp.h
@@ -15,64 +15,61 @@
 	     East Lansing, MI 48824-1321
 */
 
-
-
-// Class: CMySpecTclApp            //ANSI C++
-// File: MySpecTclApp.h
-/*
-  The user creates this subclass and fills in the appropriate overrides for any 
-  additions they want to make.  The class is a self contained example which 
-  registers two event processors.  One which unpacks a simple fixed length
-  event and another which produces a pseudo parameter from the sum of 
-  the first two parameters in an event.
-*/
-// Author:
-//   Ron Fox
-//   NSCL
-//   Michigan State University
-//   East Lansing, MI 48824-1321
-//   mailto:fox@nscl.msu.edu
-//
-// Copyright 
-
-#ifndef MYSPECTCLAPP_H  //Required for current class
+#ifndef MYSPECTCLAPP_H
 #define MYSPECTCLAPP_H
 
-// Include files:
-// Required for base classes
-
+// Required for the base class:
 #include "TclGrammerApp.h"
 
+//________________________________________________________________________
+// The user creates this subclass and fills in the appropriate overrides for
+// any additions they want to make. The class is a self contained example
+// which registers an event processor
+//
 class CMySpecTclApp : public CTclGrammerApp {
- public:
-  // Constructors:
-  CMySpecTclApp(); //Default constructor alternative to compiler provided default constructor.
-  ~CMySpecTclApp(); //Destructor - Delete any pointer data members that used new in constructors
-  //Destructor should be virtual if and only if class contains at least one virtual function
-  //Objects destroyed in the reverse order of the construction order
- private:
-  CMySpecTclApp(const CMySpecTclApp& aCMySpecTclApp ); // Copy Constructor.
+public:
+    /**
+     * @brief Default constructor.
+     * 
+     * @details 
+     * Default constructor alternative to compiler-provided default ctor.
+     */
+    CMySpecTclApp();
+    /**
+     * @brief Destructor.
+     * 
+     * @details
+     * Delete any pointer data members that used new in ctors. The destructor 
+     * should be virtual if and only if class contains at least one virtual 
+     * function. Objects should be destroyed in the reverse order of the 
+     * construction order.
+     */
+    ~CMySpecTclApp();
+    
+private:
+    /** @brief Copy constructor. */
+    CMySpecTclApp(const CMySpecTclApp& aCMySpecTclApp);
 
-  // Operators:
-  CMySpecTclApp& operator=(const CMySpecTclApp& aCMySpecTclApp);
-  int operator==(const CMySpecTclApp& aCMySpecTclApp) const;
+    // Operators:
+    CMySpecTclApp& operator=(const CMySpecTclApp& aCMySpecTclApp);
+    int operator==(const CMySpecTclApp& aCMySpecTclApp) const;
 
-  // Class operations:
- public:
-  virtual void BindTCLVariables(CTCLInterpreter& rInterp);
-  virtual void SourceLimitScripts(CTCLInterpreter& rInterpreter);
-  virtual void SetLimits();
-  virtual void CreateHistogrammer();
-  virtual void SelectDisplayer(UInt_t nDisplaySize,
-			       CHistogrammer& rHistogrammer);
-  virtual void SetupTestDataSource();
-  virtual void CreateAnalyzer(CEventSink* pSink);
-  virtual void SelectDecoder(CAnalyzer& rAnalyzer);
-  virtual void CreateAnalysisPipeline(CAnalyzer& rAnalyzer);
-  virtual void AddCommands(CTCLInterpreter& rInterp);
-  virtual void SetupRunControl();
-  virtual void SourceFunctionalScripts(CTCLInterpreter& rInterp);
-  virtual int operator()();
+public:
+    virtual void BindTCLVariables(CTCLInterpreter& rInterp);
+    virtual void SourceLimitScripts(CTCLInterpreter& rInterpreter);
+    virtual void SetLimits();
+    virtual void CreateHistogrammer();
+    virtual void SelectDisplayer(
+	UInt_t nDisplaySize, CHistogrammer& rHistogrammer
+	);
+    virtual void SetupTestDataSource();
+    virtual void CreateAnalyzer(CEventSink* pSink);
+    virtual void SelectDecoder(CAnalyzer& rAnalyzer);
+    virtual void CreateAnalysisPipeline(CAnalyzer& rAnalyzer);
+    virtual void AddCommands(CTCLInterpreter& rInterp);
+    virtual void SetupRunControl();
+    virtual void SourceFunctionalScripts(CTCLInterpreter& rInterp);
+    virtual int operator()();
 };
 
 #endif

--- a/main/ddas/src/SpecTclInit.tcl
+++ b/main/ddas/src/SpecTclInit.tcl
@@ -1,0 +1,19 @@
+set DisplayMegabytes 200
+
+# Use QtPy GUI. Comment out for Xamine.
+set DisplayType qtpy
+
+# REST interface configuration:
+set NonDAQHTTPDPort 6675
+set NonDAQMirrorPort 5565
+ 
+lappend auto_path [file join $SpecTclHome TclLibs]
+if {[array names env DAQTCLLIBS]  ne ""} {
+    lappend auto_path $env(DAQTCLLIBS)
+    package require DAQService
+    set HTTPDPort [SpecTcl::getServicePort SpecTcl_REST]
+    set MirrorPort [SpecTcl::getServicePort SpecTcl_MIRROR]
+} else {
+    set HTTPDPort $NonDAQHTTPDPort
+    set MirrorPort $NonDAQMirrorPort
+}

--- a/main/ddas/src/SpecTclRC.tcl
+++ b/main/ddas/src/SpecTclRC.tcl
@@ -1,0 +1,65 @@
+#
+#  Setup the standard scripted commandsin SpecTcl.
+#
+
+package require Tk
+tk appname SpecTcl
+
+# To SpecTcl paramters as ROOT trees uncomment the following lines:
+#load $SpecTclHome/lib/libRootInterface.so
+#package require rootinterface
+
+puts -nonewline "Loading SpecTcl gui..."
+source $SpecTclHome/Script/gui.tcl
+puts  "Done."
+
+puts -nonewline "Loading state I/O scripts..."
+source $SpecTclHome/Script/fileall.tcl
+puts "Done."
+
+puts -nonewline "Loading formatted listing scripts..."
+source $SpecTclHome/Script/listall.tcl
+puts "Done."
+
+puts -nonewline "Loading gate copy script procs..."
+source $SpecTclHome/Script/CopyGates.tcl
+puts "Done."
+
+if {$tcl_platform(os) != "Windows NT"} {
+	puts -nonewline "Loading TKCon console..."
+	source $SpecTclHome/Script/tkcon.tcl
+	puts "Done."
+}
+
+
+puts "Adding SpecTcl exec directory to auto_path"
+
+set llnlSpecTcl [file dirname [info script]]
+lappend auto_path $llnlSpecTcl
+
+puts "done"
+
+tk appname SpecTcl-[exec hostname]-[pid]
+
+##
+# Configure the VM-USB unpacker software:
+#
+# You should probably change the code below to 
+# load the configuration file of your choice.
+#
+
+set daqconfig [file join ~ config daqconfig.tcl]; # default config file.
+
+lappend auto_path [file join $SpecTclHome TclLibs]
+package require vmusbsetup
+
+vmusbConfig $daqconfig
+
+
+##
+# Start the main GUI.
+
+puts -nonewline "Starting treeparamgui..."
+source $SpecTclHome/Script/SpecTclGui.tcl
+puts " Done"
+


### PR DESCRIPTION
- Updated DDAS skeleton for DDAS tutorial pages
- Fix a typo in configure.ac that caused libtcl to be incorporated always even if already incorp'd
- Remove hardcoded ROOT include path from Core/Makefile.am which caused build and unittest failures if the hardcoded path was mounted in the container