### PR TITLE
Rfoxkendo/issue127  - Handle exit segfaults

### DIFF
--- a/main/Core/EventMessage.cpp
+++ b/main/Core/EventMessage.cpp
@@ -287,5 +287,6 @@ stopHistogramPump() {
         fakeEvents[0] = new CEvent;
         HistogramEvents(fakeEvents);
         Tcl_JoinThread(pumpThread, &exitStatus);  // Don't carea aboput the exit status.
+        std::cerr << "Histogram pump thread joined\n";
     }
 }

--- a/main/Core/EventMessage.cpp
+++ b/main/Core/EventMessage.cpp
@@ -257,7 +257,7 @@ void HistogramEvents(CEventList& events) {
  * 
 */
 void startHistogramPump() {
-    
+    RegisterTypes();
     mainThread = Tcl_GetCurrentThread();
     if (pumping) {
         stopHistogramPump();
@@ -284,6 +284,7 @@ stopHistogramPump() {
         int exitStatus;
         pumping = false;          // Stop on next message.
         CEventList fakeEvents(1);
+        fakeEvents[0] = new CEvent;
         HistogramEvents(fakeEvents);
         Tcl_JoinThread(pumpThread, &exitStatus);  // Don't carea aboput the exit status.
     }

--- a/main/Core/EventMessage.cpp
+++ b/main/Core/EventMessage.cpp
@@ -287,6 +287,5 @@ stopHistogramPump() {
         fakeEvents[0] = new CEvent;
         HistogramEvents(fakeEvents);
         Tcl_JoinThread(pumpThread, &exitStatus);  // Don't carea aboput the exit status.
-        std::cerr << "Histogram pump thread joined\n";
     }
 }

--- a/main/Core/FilterDictionary.cpp
+++ b/main/Core/FilterDictionary.cpp
@@ -55,6 +55,7 @@ CFilterDictionary* CFilterDictionary::GetInstance() {
 void
 CFilterDictionary::onExit()
 {
+  std::cerr << "Filter dict exit handler\n";
   // Don't need to do anything if no filters
 
   cerr << "closing off filters\n";
@@ -70,4 +71,5 @@ CFilterDictionary::onExit()
       p++;
     }
   }
+  std::cerr << "Filter dict exit handler done\n";
 }

--- a/main/Core/FilterDictionary.cpp
+++ b/main/Core/FilterDictionary.cpp
@@ -55,7 +55,6 @@ CFilterDictionary* CFilterDictionary::GetInstance() {
 void
 CFilterDictionary::onExit()
 {
-  std::cerr << "Filter dict exit handler\n";
   // Don't need to do anything if no filters
 
   cerr << "closing off filters\n";
@@ -65,11 +64,11 @@ CFilterDictionary::onExit()
     while(p != m_pInstance->end()) {
       CGatedEventFilter* pFilter = p->second;
       if(pFilter->CheckEnabled()) {
-	pFilter->Disable();
-	cerr << "Closed filter: " << p->first << endl;
+        pFilter->Disable();
+        cerr << "Closed filter: " << p->first << endl;
       }
       p++;
     }
   }
-  std::cerr << "Filter dict exit handler done\n";
 }
+ 

--- a/main/Core/GateCommand.h
+++ b/main/Core/GateCommand.h
@@ -141,6 +141,7 @@ public:
   void   invokeAScript(CTCLObject* pScript, std::string parameter);
 
 
+  static void stopTracePump();
 
 protected:
 
@@ -158,6 +159,7 @@ private:
   static Tcl_ThreadCreateType mpiTraceRelayCatchThread(ClientData command);
   static int traceRelayEventHandler(Tcl_Event* pEvent, int flags);
   void startTracePump();
+  
 #endif
 
 };

--- a/main/Core/GatePump.cpp
+++ b/main/Core/GatePump.cpp
@@ -413,7 +413,6 @@ receiveGate() {
             throw std::runtime_error("receiveGate failed to get name and type");
         }
         if (buffer.s_gateType == -1) {
-            std::cerr << "Got an end gate marker " << myRank() << std::endl;
             delete result;
             return nullptr;
         }
@@ -651,13 +650,11 @@ broadcastGate(std::string name, CGate* pGate) {
  * results in the thread exiting.
 */
 void stopGatePump() {
-    std::cerr << "Stop gate Pump " << myRank() << std::endl;
     GateNameAndType msg;
     msg.s_gateType = -1;
     strncpy(msg.s_gateName, "dummy", MAX_GATENAME);
 
     MPI_Bcast(&msg, 1, nameAndType(), MPI_EVENT_SINK_RANK, gXamineGateComm);
-    std::cerr << " Sent\n";
 
 }
 

--- a/main/Core/GatePump.cpp
+++ b/main/Core/GatePump.cpp
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <vector>
 #include <Globals.h>
+#include <iostream>
 
 #include "Cut.h"
 #include "PointlistGate.h"
@@ -32,6 +33,7 @@
 #include "CGammaContour.h"
 #ifdef WITH_MPI
 #include <mpi.h>
+#include <TclPump.h>
 #endif
 #include <tcl.h>
 
@@ -411,6 +413,7 @@ receiveGate() {
             throw std::runtime_error("receiveGate failed to get name and type");
         }
         if (buffer.s_gateType == -1) {
+            std::cerr << "Got an end gate marker " << myRank() << std::endl;
             delete result;
             return nullptr;
         }
@@ -648,11 +651,14 @@ broadcastGate(std::string name, CGate* pGate) {
  * results in the thread exiting.
 */
 void stopGatePump() {
+    std::cerr << "Stop gate Pump " << myRank() << std::endl;
     GateNameAndType msg;
     msg.s_gateType = -1;
     strncpy(msg.s_gateName, "dummy", MAX_GATENAME);
 
     MPI_Bcast(&msg, 1, nameAndType(), MPI_EVENT_SINK_RANK, gXamineGateComm);
+    std::cerr << " Sent\n";
+
 }
 
 

--- a/main/Core/GatePump.cpp
+++ b/main/Core/GatePump.cpp
@@ -410,6 +410,10 @@ receiveGate() {
             ) != MPI_SUCCESS) {
             throw std::runtime_error("receiveGate failed to get name and type");
         }
+        if (buffer.s_gateType == -1) {
+            delete result;
+            return nullptr;
+        }
         result->s_type = static_cast<GateType_t>(buffer.s_gateType);
         result->s_name = buffer.s_gateName;
     }
@@ -549,9 +553,11 @@ gateThread (ClientData cd) {
         p->s_base.proc = gateEventHandler;
         p->s_base.nextPtr = nullptr;
         p->s_pGate = receiveGate();
+        if (!p->s_pGate) break;             // Exit msg.
         Tcl_ThreadQueueEvent(interpThread, &(p->s_base), TCL_QUEUE_TAIL);
         Tcl_ThreadAlert(interpThread);
     }
+     TCL_THREAD_CREATE_RETURN;
 }
 
 
@@ -565,6 +571,7 @@ gateThread (ClientData cd) {
 */
 void startGatePump() {
 #ifdef WITH_MPI
+    RegisterTypes();
     if (gMPIParallel) {
         interpThread = Tcl_GetCurrentThread();
         Tcl_ThreadId listener;
@@ -630,10 +637,23 @@ broadcastGate(std::string name, CGate* pGate) {
         }
 
     }
+
+
     
 #endif
 }
+/**
+ * stop the gate pump thread...we send a dummy gate with a type of -1
+ * When receive gate gets that it will return a null gate which 
+ * results in the thread exiting.
+*/
+void stopGatePump() {
+    GateNameAndType msg;
+    msg.s_gateType = -1;
+    strncpy(msg.s_gateName, "dummy", MAX_GATENAME);
 
+    MPI_Bcast(&msg, 1, nameAndType(), MPI_EVENT_SINK_RANK, gXamineGateComm);
+}
 
 
 

--- a/main/Core/GatePump.h
+++ b/main/Core/GatePump.h
@@ -39,5 +39,6 @@ class CGate;
 
 
 void startGatePump();
+void stopGatePump();
 void broadcastGate(std::string name, CGate* pGate);
 #endif

--- a/main/Core/Histogrammer.h
+++ b/main/Core/Histogrammer.h
@@ -213,6 +213,7 @@ class CHistogrammer : public CEventSink {
 static const int TRACE_ADD_GATE(1);
 static const int TRACE_REMOVE_GATE(2);
 static const int TRACE_MODIFY_GATE(3);
+static const int TRACE_EXIT_THREAD(4);
 #define MAX_GATE_NAME 256     // Hopefully enough.
 struct TraceRelay {            // trace message body.
   int s_traceType;             // Type of trace -see above.

--- a/main/Core/RingItemPump.cpp
+++ b/main/Core/RingItemPump.cpp
@@ -207,7 +207,7 @@ assembleTargetedData(pRingItemEvent pEvent) {
     
     // How much data shoulid we get (assume we got at least the first long)
     uint32_t* pSize = reinterpret_cast<uint32_t*>(pEvent->s_pData);
-    if (pSize == 0) {
+    if (*pSize == 0) {
         // end marker.
         Tcl_Free(reinterpret_cast<char*>(pEvent->s_pData));
         pEvent->s_pData = nullptr;
@@ -325,7 +325,7 @@ physicsThread(ClientData parent) {
             0, MPI_RING_ITEM_TAG, gRingItemComm
         );
         if(status != MPI_SUCCESS) {
-            std::cerr << "MPI Stauts on send error in pump: " << status << std::endl;
+            std::cerr << "MPI Status on send error in pump: " << status << std::endl;
             throw std::runtime_error("Worker failed to request a work item");
         }
         

--- a/main/Core/RingItemPump.cpp
+++ b/main/Core/RingItemPump.cpp
@@ -191,10 +191,12 @@ assembleTargetedData(pRingItemEvent pEvent) {
     if (!pEvent->s_pData) {
         throw std::runtime_error("Tcl_Alloc failed in assembleTargetedData");
     }
+    // Note this recv must allow sends from anywhere as we may send ourselves
+    // a message to stop.
     MPI_Status status;
     if (MPI_Recv
         (pEvent->s_pData, MAX_MESSAGE_SIZE, MPI_UINT8_T,
-         0, MPI_RING_ITEM_TAG, gRingItemComm, &status
+         MPI_ANY_SOURCE, MPI_RING_ITEM_TAG, gRingItemComm, &status
         ) != MPI_SUCCESS) {
             throw std::runtime_error("Failed to receive a chunk in assembleTargetedData");
     }
@@ -226,7 +228,7 @@ assembleTargetedData(pRingItemEvent pEvent) {
         while (remainingSize) {
             if (MPI_Recv(
                 p, remainingSize, MPI_UINT8_T, 
-                0, MPI_RING_ITEM_TAG, gRingItemComm, &status
+                MPI_ANY_SOURCE, MPI_RING_ITEM_TAG, gRingItemComm, &status
             ) != MPI_SUCCESS) {
                 throw std::runtime_error("Failed to receive a chunk in assembleTargetedData");
             }

--- a/main/Core/RingItemPump.h
+++ b/main/Core/RingItemPump.h
@@ -36,4 +36,5 @@ void sendRingItem(const void* pItem, size_t size);
 void broadcastRingItem(const void* pItem, size_t size);
 
 void startRingItemPump();
+void stopRingItemPump();
 #endif

--- a/main/Core/TclGrammerApp.cpp
+++ b/main/Core/TclGrammerApp.cpp
@@ -1504,6 +1504,14 @@ MpiExitHandler() {
       exitCommand.commandChunk[exitCommand.commandLength - 1] = '\0';
 
       MPI_Bcast(&exitCommand, 1, getTclCommandChunkType(), MPI_ROOT_RANK, MPI_COMM_WORLD);
+      stopCommandPump();     // Broadcasts the dummy exit thing
+    } 
+    if (myRank() == MPI_EVENT_SINK_RANK) {
+      // Stop the histogram pump:
+      stopHistogramPump();
+      stopGatePump();            // We broadcast the stop message.
+    } else {
+      stopRingItemPump();
     }
   
     MPI_Finalize();   // Ignore status - might have already been called.

--- a/main/Core/TclGrammerApp.cpp
+++ b/main/Core/TclGrammerApp.cpp
@@ -1505,7 +1505,7 @@ int CTclGrammerApp::AppInit(Tcl_Interp *pInterp)
 static void
 MpiExitHandler() {
 #ifdef WITH_MPI
-  std::cerr << "MPI exit handler for " << myRank() << std::endl;
+
   // Note that if we are rank 0 we spray the exit command to all of the
   // other ranks.  Sincde exit won't make a status, we don't get replies.
   if (gMPIParallel) {
@@ -1514,23 +1514,15 @@ MpiExitHandler() {
       exitCommand.commandLength = strlen("exit") + 1;
       strcpy(exitCommand.commandChunk, "exit");
       exitCommand.commandChunk[exitCommand.commandLength - 1] = '\0';
-      std::cerr << "Exit handler sending: \n";
-      std::cerr << "size: " << exitCommand.commandLength << std::endl;
-      std::cerr << "String: " << exitCommand.commandChunk << std::endl;
       MPI_Bcast(&exitCommand, 1, getTclCommandChunkType(), MPI_ROOT_RANK, MPI_COMM_WORLD);
-      std::cerr << "Stopping the pump\n";
       stopCommandPump();     // Broadcasts the dummy exit thing
       
     } 
     if (myRank() == MPI_EVENT_SINK_RANK) {
       // Stop the histogram pump:
       stopHistogramPump();
-      std::cerr << " stopping gate pump for " << myRank() << std::endl;
       stopGatePump();            // We broadcast the stop message.
-      std::cerr << "Stopped\n";
-      std::cerr << "Stopping trace pump\n";
       CGateCommand::stopTracePump();
-      std::cerr << "Stopped\n";
     }  else {
       // Root or worker can call this:
       //    - Root will broadcast a dummy event to kill the broadcast recieve thread and
@@ -1539,7 +1531,6 @@ MpiExitHandler() {
     } 
     sleep(2);         // Let all the thread exit before pulling the MPI  rug out.
 
-    std::cerr << "Rank " << myRank() << " Entering MPI_RINALIZE\n";
     MPI_Finalize();   // Ignore status - might have already been called.
   }
 #endif

--- a/main/Core/TclGrammerApp.cpp
+++ b/main/Core/TclGrammerApp.cpp
@@ -1506,15 +1506,19 @@ MpiExitHandler() {
 
       MPI_Bcast(&exitCommand, 1, getTclCommandChunkType(), MPI_ROOT_RANK, MPI_COMM_WORLD);
       stopCommandPump();     // Broadcasts the dummy exit thing
+      
     } 
     if (myRank() == MPI_EVENT_SINK_RANK) {
       // Stop the histogram pump:
       stopHistogramPump();
       stopGatePump();            // We broadcast the stop message.
       CGateCommand::stopTracePump();
-    } else {
-      stopRingItemPump();
-    }
+    }  else {
+      // Root or worker can call this:
+      //    - Root will broadcast a dummy event to kill the broadcast recieve thread and
+      //    - Workers will send themselves a dummy event to kill the MPI_Recv thread.
+      stopRingItemPump(); 
+    } 
     sleep(2);         // Let all the thread exit before pulling the MPI  rug out.
     MPI_Finalize();   // Ignore status - might have already been called.
   }

--- a/main/Core/TclGrammerApp.cpp
+++ b/main/Core/TclGrammerApp.cpp
@@ -48,6 +48,7 @@ static const char* Copyright = "(C) Copyright Michigan State University 2008, Al
 #include "CSpectrumStatsCommand.h"
 #include "SpectrumDictionaryFitObserver.h"
 #include "GateBinderObserver.h"
+#include "GateCommand.h"
 #include "GatingDisplayObserver.h"
 #include "CHistogrammerFitObserver.h"
 
@@ -1510,10 +1511,11 @@ MpiExitHandler() {
       // Stop the histogram pump:
       stopHistogramPump();
       stopGatePump();            // We broadcast the stop message.
+      CGateCommand::stopTracePump();
     } else {
       stopRingItemPump();
     }
-  
+    sleep(2);         // Let all the thread exit before pulling the MPI  rug out.
     MPI_Finalize();   // Ignore status - might have already been called.
   }
 #endif

--- a/main/Core/TclGrammerApp.cpp
+++ b/main/Core/TclGrammerApp.cpp
@@ -1503,8 +1503,11 @@ MpiExitHandler() {
       exitCommand.commandLength = strlen("exit") + 1;
       strcpy(exitCommand.commandChunk, "exit");
       exitCommand.commandChunk[exitCommand.commandLength - 1] = '\0';
-
+      std::cerr << "Exit handler sending: \n";
+      std::cerr << "size: " << exitCommand.commandLength << std::endl;
+      std::cerr << "String: " << exitCommand.commandChunk << std::endl;
       MPI_Bcast(&exitCommand, 1, getTclCommandChunkType(), MPI_ROOT_RANK, MPI_COMM_WORLD);
+      std::cerr << "Stopping the pump\n";
       stopCommandPump();     // Broadcasts the dummy exit thing
       
     } 

--- a/main/mpi/TclPump.cpp
+++ b/main/mpi/TclPump.cpp
@@ -331,10 +331,8 @@ static int MPIExecCommand(CTCLInterpreter& interp, std::vector<CTCLObject>& word
 
         MpiTclCommandChunk chunk;
         chunk.commandLength = len + 1;           // Null terminator.
-        std::cerr << "Length: " << chunk.commandLength << std::endl;
         memset(chunk.commandChunk, 0, MAX_TCL_CHUNKSIZE);
         memcpy(chunk.commandChunk, command.substr(chunkstart, thisChunk).data(), thisChunk);
-        std::cerr << " string: " << chunk.commandChunk << std::endl;
         if (MPI_Bcast(&chunk, 1, getTclCommandChunkType(), myRank(), MPI_COMM_WORLD) != MPI_SUCCESS) {
             throw std::runtime_error("Failed to send command to slaves");
         }
@@ -506,10 +504,7 @@ static Tcl_ThreadCreateType CommandPumpThread(ClientData pData) {
             std::cerr << "Failed to receive a tcl command chunk in command pump thread\n";
             Tcl_Exit(-1);
         }
-        std::cerr << "got a command chunk for " << chunk.commandLength << std::endl;
-        std::cerr << "Chunk: "  << chunk.commandChunk << std::endl;
         if (chunk.commandLength == 0) {
-            std::cerr << "Stopping command chunk thread\n";
             break;
         }
         appendCommandChunk(event, chunk);

--- a/main/mpi/TclPump.cpp
+++ b/main/mpi/TclPump.cpp
@@ -545,7 +545,9 @@ void startCommandPump(CTCLInterpreter& rInterp) {
 #ifdef WITH_MPI
     pReceiverInterp = &rInterp;
     mainThread = Tcl_GetCurrentThread();
-    int status = Tcl_CreateThread(&pumpThread, CommandPumpThread, nullptr, TCL_THREAD_STACK_DEFAULT, TCL_THREAD_JOINABLE);
+    int status = Tcl_CreateThread(
+        &pumpThread, CommandPumpThread, nullptr, 
+        TCL_THREAD_STACK_DEFAULT, TCL_THREAD_NOFLAGS);
     if (status != TCL_OK) {
         throw std::runtime_error("Could not start command pump thread!");
     }

--- a/main/mpi/TclPump.cpp
+++ b/main/mpi/TclPump.cpp
@@ -581,7 +581,7 @@ void stopCommandPump() {
             throw std::runtime_error("stopCommandPump could not stop the pump");
         }
         int pumpResult;
-        Tcl_JoinThread(pumpThread, &pumpResult);
+    
     }
 #endif
 }

--- a/main/mpi/TclPump.h
+++ b/main/mpi/TclPump.h
@@ -29,7 +29,7 @@ class CTCLObject;
 #define MPI_TCL_TAG  1    // Tcl commands have this tag
 #define MAX_TCL_CHUNKSIZE 50
 typedef struct _MpiTclCommandChunk {
-    int long commandLength;                     // Length of the command.
+    int commandLength;                     // Length of the command.
     char commandChunk[MAX_TCL_CHUNKSIZE];  // command chunk.
 } MpiTclCommandChunk, *pMpiTclCommandChunk;
 


### PR DESCRIPTION
These came about due to the various message -> Tcl Event pump threads and MPI segfaulting the MPI_Bcast or MPI_Recv they were hanging on so for each pump:

*  Figure out a message that unambiguously says it should exit.
*  Create a stopXXXXPump function that sends that message
* Invokes those stopXXXPump methods from the MpiExitHandler function from the appropriate ranks.