### PR TITLE
Issue #133 - Xamine would not restart..

### DIFF
--- a/main/Core/Makefile.am
+++ b/main/Core/Makefile.am
@@ -1,7 +1,7 @@
 lib_LTLIBRARIES = libSpecTclTcp.la libTclGrammerApp.la libSpecTclMain.la 
 
 libSpecTclMain_la_SOURCES=SpecTclMain.cpp
-libSpecTclMain_la_LIBADD = @builddir@/libTclGrammerApp.la @top_builddir@/mpi/libMPIUtilities.la
+libSpecTclMain_la_LIBADD = @builddir@/libTclGrammerApp.la @top_builddir@/mpi/libMPIUtilities.la @top_builddir@/Display/libXamine.la
 libSpecTclMain_la_CXXFLAGS=@LIBTCLPLUS_CFLAGS@ @TCL_CPPFLAGS@ @ROOT_CFLAGS@ \
 	-I@top_srcdir@/Utility -I@top_srcdir@/mpi
 
@@ -456,6 +456,7 @@ commonTestCXXFLAGS = -I@top_srcdir@/Core \
 commonTestLdFlags = @builddir@/libTclGrammerApp.la \
 		@builddir@/libSpecTclTcp.la \
 		@top_builddir@/mpi/libMPIUtilities.la \
+		@top_builddir@/Display/libXamine.la \
 		@LIBTCLPLUS_LDFLAGS@ \
 		@CPPUNIT_LIBS@ \
 		@TK_LIBS@ \

--- a/main/Core/TclGrammerApp.cpp
+++ b/main/Core/TclGrammerApp.cpp
@@ -1502,8 +1502,17 @@ int CTclGrammerApp::AppInit(Tcl_Interp *pInterp)
  * mpiExitHandler calles MPI_Finalize on Tcl exit:
  *    Tcl has already killed off the stdout/err so we can't really do any error handling.
  */
+
+extern int is_xamine_shm_monitor;  //it's magic... Xamine client is in C.
 static void
 MpiExitHandler() {
+  // This magic is because the Xamine client software forks us in order to
+  // clean up shared memory when there are no attaches.  forks inherit exit processors
+  // so the forked process sets is_xamine_shm_monitor true so we can 
+  // avoid doing things we really don't want to do.
+  if (is_xamine_shm_monitor) {
+    return;
+  }
 #ifdef WITH_MPI
 
   // Note that if we are rank 0 we spray the exit command to all of the

--- a/main/Display/client.c
+++ b/main/Display/client.c
@@ -101,6 +101,8 @@
 volatile Xamine_shared *Xamine_memory;
 size_t            Xamine_memsize;
 arenaid        Xamine_memory_arena;
+
+int is_xamine_shm_monitor = FALSE;
 /*
 ** Local storage:
 */
@@ -230,6 +232,8 @@ static int genmem(char *name, volatile void **ptr, unsigned int size)
   pid = fork();
   if (pid == 0) {
       struct shmid_ds stat;
+
+      is_xamine_shm_monitor = TRUE;
 
     /* child */
 

--- a/main/Display/client.h
+++ b/main/Display/client.h
@@ -219,6 +219,11 @@ void Xamine_clearStatistics(unsigned nSpetrum);
 
 int Xamine_genenv(const char* name, int specbytes);
 
+/*  This is added for mpi spectcl - we add a flag to indicate if this process */
+/* is the shmem monitor so atexits' can test for that */
+
+extern int is_xamine_shm_monitor;
+
 #if defined(__cplusplus) || defined(c_plusplus)
 }
 #endif

--- a/main/TestFiles/Makefile.am
+++ b/main/TestFiles/Makefile.am
@@ -18,7 +18,7 @@ noinst_PROGRAMS = testfile # ltwrite
 
 testfile_SOURCES = testfile.cpp
 testfile_CPPFLAGS = $(commonCPPFLAGS)
-testfile_LDADD= $(commonLDADD)
+testfile_LDADD= @top_builddir@/Display/libXamine.la $(commonLDADD)
 
 #ltwrite_SOURCES = ltwrite.cpp
 #ltwrite_CPPFLAGS = $(commonCPPFLAGS)

--- a/main/ddas/Makefile.am
+++ b/main/ddas/Makefile.am
@@ -50,7 +50,8 @@ unittests_CXXFLAGS = @CPPUNIT_CFLAGS@ @ROOT_CFLAGS@ -I@top_srcdir@/Utility \
 	-I@top_srcdir@/Core @LIBTCLPLUS_CFLAGS@ @TCL_CPPFLAGS@ 
 unittests_LDADD = @builddir@/libDDASUnpacker.la @top_builddir@/Core/libTclGrammerApp.la  \
 	@top_builddir@/mpi/libMPIUtilities.la \
-	@ROOT_LDFLAGS@  @CPPUNIT_LIBS@ @LIBTCLPLUS_LDFLAGS@ @TCL_LIBS@
+	@top_builddir@/Display/libXamine.la \
+	@ROOT_LDFLAGS@  @CPPUNIT_LIBS@ @LIBTCLPLUS_LDFLAGS@ @TCL_LIBS@ 
 TESTS_ENVIRONMENT=LD_LIBRARY_PATH=$(ROOT_LIBRARY_DIR)
 TESTS = ./unittests
 

--- a/main/filtsplit/Makefile.am
+++ b/main/filtsplit/Makefile.am
@@ -16,6 +16,7 @@ filtsplit_CFLAGS =-I@top_srcdir@/Core
 filtsplit_CXXFLAGS =-I@top_srcdir@/Core
 
 filtsplit_LDADD = @top_builddir@/Core/libTclGrammerApp.la \
+		@top_builddir@/Display/libXamine.la \
 		@top_builddir@/mpi/libMPIUtilities.la \
 		  @LIBTCLPLUS_LDFLAGS@ \
 		  @TCL_LIBS@ @ROOT_LDFLAGS@ \


### PR DESCRIPTION
This was due to the atexit handler doing MPI stuff in the shared memory cleanup monitor.  Added an Xamine global client
flag: is_xamine_shm_monitor
if set, the MpiExitHandler just returns immediatly.