### PR TITLE
Rfoxkendo/issue15

### DIFF
--- a/main/Gui/datasource.tcl
+++ b/main/Gui/datasource.tcl
@@ -200,35 +200,36 @@ proc attachDataSource {format size sourcetype sourcespec} {
 #      We need to pop up a dialog to request the node from which we take data.
 #
 proc attachOnline {} {
-    hostprompt .hostprompt -host $::GuiPrefs::preferences \
+    
+    hostprompt .hostprompt -host $::GuiPrefs::preferences(defaultRingHost) \
 	-format [defaultFormat]                          \
 	-buffersize $::GuiPrefs::preferences(defaultBuffersize)  \
-	-ringname   $::GuiPrefs::preferences(defaultRingName) \
-    #after 1 .hostprompt configure -format [defaultFormat]
+	-ringname   $::GuiPrefs::preferences(defaultRingName)
+    .hostprompt configure -format [defaultFormat]
     .hostprompt modal
     if {[winfo exists .hostprompt]} {
         set host [.hostprompt cget -host]
 
         if {$host != ""} {            
-	    set format [.hostprompt cget -format]
-	    set additionalInfo {}
+            set format [.hostprompt cget -format]
+            set additionalInfo {}
 
-	    if {[string match ring* $format]} {
-		set additionalInfo [.hostprompt cget -ringname]
-                set $::GuiPrefs::preferences(defaultRingName) $additionalInfo
+            if {[string match ring* $format]} {
+                    set additionalInfo [.hostprompt cget -ringname]
+                    set ::GuiPrefs::preferences(defaultRingName) $additionalInfo
             }
             set size [.hostprompt cget -buffersize]
-    
-            set $::GuiPrefs::preferences(defaultRingHost)     $host
-	    set ::datasource::lastformat   $format            
-	    set ::GuiPrefs::preferences(defaultBuffersize) $size
-            
-	    set helper [.hostprompt onlinehelper $host $additionalInfo]
 
+            set ::GuiPrefs::preferences(defaultRingHost)     $host
+            set ::datasource::lastformat   $format            
+            set ::GuiPrefs::preferences(defaultBuffersize) $size
+                
+            set helper [.hostprompt onlinehelper $host $additionalInfo]
             attachDataSource $format $size -pipe $helper
         }
         destroy .hostprompt
     }
+    
 }
 # attachFile
 #       Prompts for an event file to attach to and does the deed.

--- a/main/Gui/datasource.tcl
+++ b/main/Gui/datasource.tcl
@@ -27,8 +27,9 @@ package require segmentedrun
 #  Namespace to hold some of the configuration entries.
 #
 namespace eval datasource {
-    variable daqroot         [list $::daqdefs::daqroot /usr/opt/daq/current /usr/opt/daq/8.1 /usr/opt/daq/8.0  /usr/opt/daq];   # Where the DAQ software is installed.
-    variable lasthost        localhost;  # Most recent online host.
+    variable daqroot         [list $::daqdefs::daqroot \
+        ::GuiPrefs::preferences(defaultDaqRoot) /usr/opt/daq/current \
+        /usr/opt/daq/8.1 /usr/opt/daq/8.0  /usr/opt/daq];   # Where the DAQ software is installed.
     variable lastformat      ring11
     variable lasteventfile   {}
     variable lastpipecommand {}
@@ -38,7 +39,6 @@ namespace eval datasource {
     variable warnedFilters   0
     variable lastFilterFile {}
     variable actualSpecTclDaq {}
-    variable lastring      $::tcl_platform(user)
     variable clustersize   8192
     variable defaultFileBuffer [expr 128*1024];    # Better performance for files.
 
@@ -200,10 +200,10 @@ proc attachDataSource {format size sourcetype sourcespec} {
 #      We need to pop up a dialog to request the node from which we take data.
 #
 proc attachOnline {} {
-    hostprompt .hostprompt -host $::datasource::lasthost \
+    hostprompt .hostprompt -host $::GuiPrefs::preferences \
 	-format [defaultFormat]                          \
 	-buffersize $::GuiPrefs::preferences(defaultBuffersize)  \
-	-ringname   $::datasource::lastring
+	-ringname   $::GuiPrefs::preferences(defaultRingName) \
     #after 1 .hostprompt configure -format [defaultFormat]
     .hostprompt modal
     if {[winfo exists .hostprompt]} {
@@ -215,11 +215,11 @@ proc attachOnline {} {
 
 	    if {[string match ring* $format]} {
 		set additionalInfo [.hostprompt cget -ringname]
-                set ::datasource::lastring $additionalInfo
+                set $::GuiPrefs::preferences(defaultRingName) $additionalInfo
             }
             set size [.hostprompt cget -buffersize]
     
-            set ::datasource::lasthost     $host
+            set $::GuiPrefs::preferences(defaultRingHost)     $host
 	    set ::datasource::lastformat   $format            
 	    set ::GuiPrefs::preferences(defaultBuffersize) $size
             

--- a/main/Gui/folderGui.tcl
+++ b/main/Gui/folderGui.tcl
@@ -223,7 +223,13 @@ proc incrementalSource filename {
 #   We also save the new preferences for the user.
 proc editPrefs {} {
     preferences::editPrefs
-    preferences::savePrefs
+    if {[catch {preferences::savePrefs} msg] != 0} {
+        tk_messageBox \
+            -icon warning \
+            -message "Could not save preferences file $msg" \
+            -parent . -title "Preferences failed" -type ok
+    }
+    
 }
 
 
@@ -1182,8 +1188,8 @@ proc ::FolderGui::startFolderGui {{top {}} {parent {}}} {
 #
 #  setDefaultPrefs
 #     Set default values for preferences prior to reading the preferences from file:
-#
-proc setDefaultPrefs() {
+#     These are new values as of 7.0-001 - to resolve issue #15 which may not be in the file:
+proc setDefaultPrefs {} {
     set ::GuiPrefs::preferences(defaultRingName) $::tcl_platform(user)
     set ::GuiPrefs::preferences(defaultRingHost) localhost
 }

--- a/main/Gui/folderGui.tcl
+++ b/main/Gui/folderGui.tcl
@@ -1173,5 +1173,17 @@ proc ::FolderGui::startFolderGui {{top {}} {parent {}}} {
     updateStatus 1000
     set ::SpecTclIODwellMax 100
 
+    # We can stock some preferences if there's not (yet) a preferences file:
+
+    setDefaultPrefs
     preferences::readPrefs
+}
+
+#
+#  setDefaultPrefs
+#     Set default values for preferences prior to reading the preferences from file:
+#
+proc setDefaultPrefs() {
+    set ::GuiPrefs::preferences(defaultRingName) $::tcl_platform(user)
+    set ::GuiPrefs::preferences(defaultRingHost) localhost
 }

--- a/main/Gui/prefs.tcl
+++ b/main/Gui/prefs.tcl
@@ -213,9 +213,11 @@ proc preferences::editPrefs {} {
     
 }
 proc preferences::readPrefs {} {
-    if {[file readable [file join ~ $::preferences::SpecTclDefaults]]} {
+	set home ~$::tcl_platform(user)
+	set prefFile [file join $home $::preferences::SpecTclDefaults]
+    if {[file readable $prefFile]} {
 	namespace eval ::GuiPrefs {
-	    source [file join ~ $::preferences::SpecTclDefaults]
+	    source [file $prefFile]
 	}
     }
 }

--- a/main/Gui/prefs.tcl
+++ b/main/Gui/prefs.tcl
@@ -33,6 +33,7 @@ package require guihelp
 #  | NSCL DAQ:                                   |
 #  | NSCL DAQ root: [           ]  [browse...]   |
 #  | Default Buffer Size [       ]               |
+#  | Default ring host  [    ] Default Ring [   ]|
 #  +---------------------------------------------+
 #  | [Ok]   [Cancel] [Help]                      |
 #  +---------------------------------------------+
@@ -42,11 +43,15 @@ package require guihelp
 #     -ydefault   - Value in the Y axis entry.
 #     -daqroot    - Value of location of nscldaq root.
 #     -buffersize - Default buffers size in bytes on attach dialogs.
+#  Added to resolve issue #15
+#     -defaultringhost - Default host for attach online
+#     -defaultringname - Default ring name for attach online.
+#  
 #
 #     -okscript   - Script to execute on click of ok.
 #     -cancelscript - Script to execute on click of cancel.
 #     -helpscript   - Script to execute on click of help.
-
+#
 #
 #    
 snit::widget prefsEditor {
@@ -55,6 +60,8 @@ snit::widget prefsEditor {
     option   -ydefault
     option   -daqroot
     option   -buffersize
+	option   -defaultringhost
+	option   -defaultringname
 
     option   -okscript
     option   -cancelscript
@@ -85,6 +92,11 @@ snit::widget prefsEditor {
 	entry $win.daqparams.bufsize    -textvariable ${selfns}::options(-buffersize) \
 	                                -width 15
 
+	label $win.daqparams.hostlabel -text {Online Host}
+	entry $win.daqparams.host -textvariable [myvar options(-defaultringhost)]
+	label $win.daqparams.ringlabel -text {Ring Name}
+	entry $win.daqparams.ring  -textvariable [myvar options(-defaultringname)]
+
 
 	frame $win.action -relief groove -borderwidth 3
 	button $win.action.ok     -text Ok -command       [mymethod dispatch -okscript]
@@ -100,6 +112,8 @@ snit::widget prefsEditor {
 	grid $win.daqparams.title       -                       -
 	grid $win.daqparams.rootlbl     $win.daqparams.root   $win.daqparams.browse
 	grid $win.daqparams.bufsizelbl  $win.daqparams.bufsize    x
+	grid $win.daqparams.hostlabel $win.daqparams.host \
+		 $win.daqparams.ringlabel $win.daqparams.ring
 	grid $win.daqparams        -columnspan 3 -sticky ew
 
 
@@ -170,6 +184,8 @@ proc preferences::ok {} {
     set ::GuiPrefs::preferences(defaultYChannels) [.prefs cget -ydefault]
     set ::GuiPrefs::preferences(defaultDaqRoot)   [.prefs cget -daqroot]
     set ::GuiPrefs::preferences(defaultBuffersize) [.prefs cget -buffersize]
+	set ::GuiPrefs::preferences(defaultRingHost)  [.prefs cget -defaultringhost]
+	set ::GuiPrefs::preferences(defaultRingName)  [.prefs cget -defaultringname]
     destroy .prefs
 }
 proc preferences::cancel {} {
@@ -184,6 +200,8 @@ proc preferences::editPrefs {} {
 	                -ydefault $::GuiPrefs::preferences(defaultYChannels) \
 	                -daqroot  $::GuiPrefs::preferences(defaultDaqRoot)   \
 	                -buffersize $::GuiPrefs::preferences(defaultBuffersize) \
+					-defaultringhost $::GuiPrefs::preferences(defaultRingHost) \
+					-defaultringname $::GuiPrefs::preferences(defaultRingName) \
 	-okscript     preferences::ok                                            \
 	-cancelscript preferences::cancel                                   \
         -helpscript   preferences::help

--- a/main/Gui/prefs.tcl
+++ b/main/Gui/prefs.tcl
@@ -220,10 +220,11 @@ proc preferences::readPrefs {} {
     }
 }
 proc preferences::savePrefs {} {
-    set fd [open [file join ~ $::preferences::SpecTclDefaults] w]
+	set home ~$::tcl_platform(user)
+	set fd [open [file join $home $::preferences::SpecTclDefaults] w]
     puts $fd "# SpecTcl gui preferences written [clock format [clock seconds]]"
     foreach pref [array names GuiPrefs::preferences] {
-	puts $fd "set preferences($pref) $GuiPrefs::preferences($pref)"
+		puts $fd "set preferences($pref) $GuiPrefs::preferences($pref)"
     }
     close $fd
 }

--- a/main/configure.ac
+++ b/main/configure.ac
@@ -1,6 +1,6 @@
 # Process this file with autoconf to produce a configure script.
 
-AC_INIT(SpecTcl,7.0-000, daqhelp@frib.msu.edu)
+AC_INIT(SpecTcl,7.0-001, daqhelp@frib.msu.edu)
 
 AC_CONFIG_AUX_DIR(config)
 AM_INIT_AUTOMAKE([tar-ustar foreign])


### PR DESCRIPTION
Note this resolves Issue #15 and also fixes the problem that env(HOME) is overwitten by tclhttpd startup -- opens the preference file via [file join ~$::tcl_platform(user) .SpecTclDefaults]  which works even if HOME was killed - unless the user mungs tcl_platform