### PR TITLE
additional issue #203 fixes - unpack ddas data

### DIFF
--- a/main/Core/TCLAnalyzer.cpp
+++ b/main/Core/TCLAnalyzer.cpp
@@ -213,6 +213,10 @@ UInt_t CTclAnalyzer::OnEvent(Address_t pRawData, CEvent& anEvent) {
       IncrementCounter(EventsRejectedThisRun);
       throw;
     }
+    catch (std::exception& e) {
+	cerr << p->first << " exception: " << e.what() << std::endl;
+	success = kfFALSE;
+    }
     catch (...) {
       cerr << "Event processor" << p->first << " threw an unanticipated exception " << endl;
       success = kfFALSE;

--- a/main/Core/TCLAnalyzer.cpp
+++ b/main/Core/TCLAnalyzer.cpp
@@ -214,11 +214,11 @@ UInt_t CTclAnalyzer::OnEvent(Address_t pRawData, CEvent& anEvent) {
       throw;
     }
     catch (std::exception& e) {
-	cerr << p->first << " exception: " << e.what() << std::endl;
+	cerr << "Event processor " << p->first << " threw std::exception: " << e.what() << std::endl;
 	success = kfFALSE;
     }
     catch (...) {
-      cerr << "Event processor" << p->first << " threw an unanticipated exception " << endl;
+      cerr << "Event processor " << p->first << " threw an unanticipated exception " << endl;
       success = kfFALSE;
     }
     if(!success) {

--- a/main/ddas/DDASBuiltFitUnpacker.h
+++ b/main/ddas/DDASBuiltFitUnpacker.h
@@ -21,7 +21,7 @@
 
 #include <config.h>
 #include <FragmentIndex.h>
-#include "DDASFitHit.h"
+#include <DDASFitHit.h>
 
 #include <EventProcessor.h>
 #include <TranslatorPointer.h>

--- a/main/ddas/DDASBuiltUnpacker.cpp
+++ b/main/ddas/DDASBuiltUnpacker.cpp
@@ -129,6 +129,7 @@ namespace DAQ {
 
       auto pBody      = reinterpret_cast<const uint32_t*>(info.s_itembody);
       size_t bodySize = *pBody; // # of 16-bit words in body (inclusive)
+      std::cerr << std::hex << bodySize << " " << std::dec << bodySize << std::endl;
 
       // parse the body of the ring item 
 

--- a/main/ddas/DDASBuiltUnpacker.cpp
+++ b/main/ddas/DDASBuiltUnpacker.cpp
@@ -5,6 +5,7 @@
 
 #include <DDASHit.h>
 #include <DDASHitUnpacker.h>
+#include <DataFormat.h>
 
 #include "Globals.h"
 #include <TCLAnalyzer.h>
@@ -120,22 +121,45 @@ namespace DAQ {
         return kfTRUE;
     }
 
-    ////////
-    ///
-    Bool_t CDDASBuiltUnpacker::parseAndStoreFragment(::ufmt::FragmentInfo& info) 
+      /////////
+      ///
+      /**
+       * @note ASC (11/6/25): Follow procedure outlined in
+       * DDASBuiltFitUnpacker and DDASFitHitUnpacker:
+       *   - Cast fragment to ring item
+       *   - Check if the body header is empty or not and set the body
+       *     pointer appropriately
+       *   - Calculate the body size and define the extent of the hit
+       *   - Unpack
+       */
+      Bool_t CDDASBuiltUnpacker::parseAndStoreFragment(::ufmt::FragmentInfo& info) 
     {
+	DDASHitUnpacker unpacker; // DDASFormat hit unpacker
+	DDASHit hit;              // Unpacked data goes here
+	const uint32_t* pBody;    // Pointer to Pixie data payload
+	uint32_t bodyHeaderSize;  // Bytes in body header
 
-      DDASHitUnpacker unpacker;
+	auto pItem = reinterpret_cast<const ::ufmt::RingItem*>(info.s_itemhdr);
+	
+	// RingItem struct allows us to discriminate between data formats:
+	// either s_mbz == 0 in the case of no body header or it is the first
+	// 32-bit word of the header (size word) and is therefore non-zero
+	
+	if (pItem->s_body.u_noBodyHeader.s_mbz) {
+	    pBody = reinterpret_cast<const uint32_t*>(pItem->s_body.u_hasBodyHeader.s_body);
+	    bodyHeaderSize = pItem->s_body.u_hasBodyHeader.s_bodyHeader.s_size;
+	} else {
+	    pBody = reinterpret_cast<const uint32_t*>(pItem->s_body.u_noBodyHeader.s_body);
+	    bodyHeaderSize = sizeof(uint32_t);
+	}
 
-      auto pBody      = reinterpret_cast<const uint32_t*>(info.s_itembody);
-      size_t bodySize = *pBody; // # of 16-bit words in body (inclusive)
-      std::cerr << std::hex << bodySize << " " << std::dec << bodySize << std::endl;
+	uint32_t bodySize = pItem->s_header.s_size - bodyHeaderSize - sizeof(::ufmt::RingItemHeader);
+	const uint32_t* pEnd = pBody + bodySize;
 
-      // parse the body of the ring item 
-
-      m_channelList.emplace(m_channelList.end());
-      unpacker.unpack(pBody, pBody+bodySize/sizeof(uint16_t), m_channelList.back() );
-      return kfTRUE;
+	unpacker.unpack(pBody, pEnd, hit);
+	m_channelList.push_back(hit);
+	
+	return kfTRUE;
     }
 
   } // end DDAS namespace

--- a/main/ddas/DDASBuiltUnpacker.h
+++ b/main/ddas/DDASBuiltUnpacker.h
@@ -20,7 +20,7 @@
 #define DAQ_DDAS_DDASBUILTUNPACKER_H
 
 #include <config.h>
-#include "FragmentIndex.h"
+#include <FragmentIndex.h>
 #include <DDASHit.h>
 
 #include <EventProcessor.h>

--- a/main/ddas/DDASBuiltUnpacker.h
+++ b/main/ddas/DDASBuiltUnpacker.h
@@ -20,7 +20,7 @@
 #define DAQ_DDAS_DDASBUILTUNPACKER_H
 
 #include <config.h>
-#include <FragmentIndex.h>
+#include "FragmentIndex.h"
 #include <DDASHit.h>
 
 #include <EventProcessor.h>
@@ -159,7 +159,6 @@ namespace DAQ {
 } // end DAQ namespace
 
 #endif
-
 
 
 

--- a/main/ddas/DDASUnpacker.h
+++ b/main/ddas/DDASUnpacker.h
@@ -132,4 +132,3 @@ namespace DAQ {
 
 
 
-


### PR DESCRIPTION
Additional fixes for issue #203 ensure default DDAS unpacker supports unpacking ddas data w/o fit extensions. basically following the procedure of DDASToys' DDASHitUnpacker and SpecTcl's DDASBuiltFitUnpacker - cast FragmentInfo to ring item, determine the body size by parsing the ring item info