### PR TITLE
Rfoxkendo/issue212

### DIFF
--- a/main/Core/CWaveForm.cpp
+++ b/main/Core/CWaveForm.cpp
@@ -19,7 +19,9 @@
  */
 #include "CWaveForm.h"
 #include <CNoSuchObjectException.h>
+#include "CDuplicateSingleton.h"
 #include <string.h>                 // memcpy.
+
 
 /**
  * m_idIndex is an indes to be passed to the NamedObject constructor
@@ -130,6 +132,152 @@ void
 CWaveform::resize(unsigned nSamples) {
     m_trace.resize(nSamples);
     memset(m_trace.data(), 0, nSamples*sizeof(uint16_t));
+
+    // Need to also resize all the fits:
+
+    for(auto& namedfit : m_fitDictionary) {
+        m_fits.at(namedfit.second).resize(nSamples);
+
+        // Assumes 0.0 is all bytes zero:
+        memset(m_fits.at(namedfit.second).data(), 0, nSamples*sizeof(double));  // FIll with zeros.
+    }
+}
+
+////////////////////////// Support for fits Issue #212 ///////////////////////
+
+/**
+ * addFit
+ *    Add a new fit to the  list of fits.  A new fit waveform is allocated
+ * with the same size as the parent waveform.  Name of the new fit is entered into the
+ * fit dictionary and associated with the index of the added fit waveform.
+ *    @param name - name of the new fit, must be unique within the fits for the waveform.
+ *                  can be duplicated in a different waveform.. e.g. more than one waveform
+ *                  can have a fit named 'fit'.
+ *    @returns size_t - id of the fit. Passing this to e.g. fillFit will fill the fit
+ *                  named by this call.
+ *    @throw CDuplicateSingleton - the fit already exists.
+ */
+size_t 
+CWaveform::addFit(const char* name) {
+    std::string sname(name);
+    if (m_fitDictionary.find(sname) == m_fitDictionary.end()) {
+        // we can enter it.
+
+        Fit_t fit;
+        fit.resize(size());        // It has our size... .this fills with 0s.
+        m_fits.push_back(fit);
+        size_t id = m_fits.size() - 1;
+        m_fitDictionary[name] = id;
+        return id;
+    } else {
+        // Duplicate:
+
+        throw CDuplicateSingleton("Waveform already has a fit with this name", name);
+    }
+
+}
+/**
+ * findFit
+ *    Get the id fof a fit from its name. 
+ * 
+ * @param name - name seeking.
+ * @return size_t id of the fit.
+ * @throw CNoSuchObjectException - no such fit name exists.
+ */
+
+ size_t
+ CWaveform::findFit(const char* name) const {
+    std::string sname(name);
+    auto p = m_fitDictionary.find(sname);
+    if (p != m_fitDictionary.end()) {
+        return p->second;
+    } else {
+        throw CNoSuchObjectException("No fit exists with that name", name);
+    }
+ }
+
+ /** 
+  * getFit
+  *    Return a readonly reference to the fit data for a fit given its index.
+  * 
+  * @param fitno - id of the fit, returned from addFit or findFit e.g.
+  * @return const CWaveform::Fit_t& References the waveform data.
+  * @throw CNoSuchObjectException- the fitno is invalid.
+  */
+ const CWaveform::Fit_t&
+ CWaveform::getFit(size_t fitno) const {
+    
+    if (fitno < m_fits.size()) {
+        return  m_fits[fitno];
+    } else {
+        throw CNoSuchObjectException("Fit id does not reference an existing fit.", std::to_string(fitno));
+    }
+    
+ }
+
+ /**
+  * getFit
+  *    Same as above but given the name not the id.  So essentially a findFit followed by
+  * the above.
+  * 
+  * @param fitnname - name of a fit.
+  * @return const CWaveform::Fit_t& References the waveform data.
+  * @throw CNoSuchObjectException- the fitno is invalid.
+  */
+ const CWaveform::Fit_t&
+ CWaveform::getFit(const char* name) const {
+    return getFit(findFit(name));    // Takes care of the exception too.
+ }
+
+ /**
+  * fillFit
+  *    Fills a fit with data.
+  *   @param fitno - fit id from e.g. addFit.
+  *   @param pData - Pointer to double data contaning the fit points.  There must be
+  *                 at least size() points in pData.
+  *   @throw CNoSuchObjectExceptoin - invalid fitno.
+  */
+ void 
+ CWaveform::fillFit(size_t fitno, const double* pData) {
+    const Fit_t& cfit = getFit(fitno);   // Takes care of exceptions too...
+    Fit_t& fit = const_cast<Fit_t&>(cfit);   // So we can modifity it.
+
+    memcpy(fit.data(), pData, fit.size());
+ }
+
+ /**
+  * fillFit
+  *    Fills fit with data given its name.  This is not recommended because the
+  * search time for the fit goes like log(n) n number of fits.  Better to select the
+  * fit by number as that's constant time.
+  * 
+  * @param fitName - name of the fit.
+  * @param pData   - Pointer to the data to fill the fit.
+  * @return size_t - The fit index so you only need to do this once.
+  * @throw CNoSuchObjectException - no matching fit.
+  */
+size_t
+CWaveform::fillFit(const char* fitName, const double* pData) {
+    size_t id = findFit(fitName);    // Does our throw for us.
+    fillFit(id, pData);
+
+    return id;
+}
+
+/**
+ * listFits
+ *    Returns a vector of pairs containig the name and ids of the
+ * defined fits
+ * 
+ * @return std::vector<std::string, size_t>
+ */
+std::vector<std::pair<std::string, size_t> >
+CWaveform::listFits() const {
+    std::vector<std::pair<std::string, size_t>> result;
+    for (auto p : m_fitDictionary) {
+        result.push_back({p.first, p.second});
+    }
+    return result;
 }
 
 

--- a/main/Core/CWaveForm.cpp
+++ b/main/Core/CWaveForm.cpp
@@ -242,7 +242,7 @@ CWaveform::addFit(const char* name) {
     const Fit_t& cfit = getFit(fitno);   // Takes care of exceptions too...
     Fit_t& fit = const_cast<Fit_t&>(cfit);   // So we can modifity it.
 
-    memcpy(fit.data(), pData, fit.size());
+    memcpy(fit.data(), pData, fit.size()*sizeof(double));
  }
 
  /**

--- a/main/Core/CWaveForm.h
+++ b/main/Core/CWaveForm.h
@@ -30,10 +30,14 @@
 class CWaveform : public CNamedItem {
 public:
     typedef std::map<std::string, std::string> Metadata_t;
+    typedef std::map<std::string, size_t>      FitMap_t;
     typedef std::vector<uint16_t>  WaveForm_t;
+    typedef std::vector<double>    Fit_t;       // Fits are floating point.
 private:
     Metadata_t  m_metadata;
     WaveForm_t  m_trace;
+    FitMap_t    m_fitDictionary;     // Issue #212 - Fit name -> index.
+    std::vector<Fit_t> m_fits;  // Issue #212 - Vector of fit traces.
     
     static unsigned m_idIndex;     // Used to assign ids we don't use.
 public:
@@ -55,6 +59,15 @@ public:
     void resize(unsigned nSample);        // Change # of samples.
     size_t size() const;
 
+    // Issue #212 - add fits to waveforms:
+
+    size_t addFit(const char* fitName);
+    size_t findFit(const char* fitName) const;
+    const Fit_t& getFit(size_t fitno) const;
+    const Fit_t& getFit(const char* fitName)const ;
+    void fillFit(size_t fitno, const double* pData);
+    size_t fillFit(const char* fitName, const double* pData);   // not recommended (better by index).
+    std::vector<std::pair<std::string, size_t> > listFits() const;
 
 private:
     static unsigned getid();

--- a/main/Core/CWaveformCommand.cpp
+++ b/main/Core/CWaveformCommand.cpp
@@ -80,6 +80,8 @@ CWaveformCommand::operator()(CTCLInterpreter& interp, std::vector<CTCLObject>& o
                 metadata(interp, objv);
             } else if (sub == "resize") {
                 resize(interp, objv);
+            } else if (sub == "fits") {
+                listFits(interp, objv);               // Issue #212
             } else {
                 create(interp, objv, 1);              // no subcommand, assume create.
             }
@@ -488,7 +490,89 @@ CWaveformCommand::resize(CTCLInterpreter& interp, std::vector<CTCLObject>& objv)
 
     wf->resize(newSamples);
 }
+/**
+ * listFits (Issue #212).
+ * 
+ * List waveform fits syntax:
+ * 
+ *    waveform fits wfname ?pattern?
+ * 
+ * Where:
+ *     wfname - is the name of a wave form.
+ *     pattern - is a glob pattern that restricts the fit names that will be listed.
+ *               If not supplied, the pattern defaults to "*" matching everything.
+ * 
+ *    The result is a list of dicts where the dict contents are:
+ * 
+ * *  name:  name of a fit.
+ * *  points: List of doubles that are the fit points.
+ * 
+ * @note the list could be empty if not fit names matche the pattern.
+ * 
+ * 
+ * 
+ */
+void
+CWaveformCommand::listFits(CTCLInterpreter& interp, std::vector<CTCLObject>& objv) {
+    requireAtLeast(objv, 3, "Insufficient number of command parameters");
+    requireAtMost(objv, 4, "Too many commnad line parameters");
 
+    std::string wfName = objv[2];
+
+    // Figure out the pattner.
+
+    std::string pattern       = "*";
+    if (objv.size() == 4) {
+        pattern = std::string(objv[3]);
+    }
+
+    auto wf = find(wfName.c_str());
+    if (!wf) {
+        std::stringstream smsg;
+        smsg << "waveform fits - no such waveform: " << wfName;
+        std::string msg(smsg.str());
+        throw std::invalid_argument(msg);
+    }
+
+    // List the fits and figure out the result:
+
+    auto listing = wf->listFits();
+
+    CTCLObject result;
+    result.Bind(interp);
+    for (auto& item : listing) {
+        // First, does the fit name match the pattern:
+
+        if (Tcl_StringMatch(item.first.c_str(), pattern.c_str())) {
+            
+            CTCLObject listitem;
+            listitem.Bind(interp);                // The dict we append.
+
+            // Put the fit name in the dict:
+
+            Tcl::DictPut(interp, listitem, "name", item.first.c_str());
+
+            // Marshall the fit points.
+            
+            auto& pts = wf->getFit(item.second);   // Now we have the fit points too.
+            CTCLObject ptlist;
+            ptlist.Bind(interp);
+            for (auto pt :pts) {
+                ptlist += pt;
+            }
+            // Add the fit points to the dict:
+
+            Tcl::DictPut(interp, listitem, "points", ptlist);
+
+            result += listitem;
+        }
+    }
+
+    interp.setResult(result);
+}
+/**
+ * 
+ */
 //////////////////////////////// private utilities ///////////////////////////////////////////////
 
 /**

--- a/main/Core/CWaveformCommand.cpp
+++ b/main/Core/CWaveformCommand.cpp
@@ -82,6 +82,8 @@ CWaveformCommand::operator()(CTCLInterpreter& interp, std::vector<CTCLObject>& o
                 resize(interp, objv);
             } else if (sub == "fits") {
                 listFits(interp, objv);               // Issue #212
+            } else if (sub == "getall") {
+                getAll(interp, objv);                 // Usse #212
             } else {
                 create(interp, objv, 1);              // no subcommand, assume create.
             }
@@ -540,6 +542,52 @@ CWaveformCommand::listFits(CTCLInterpreter& interp, std::vector<CTCLObject>& obj
     result.Bind(interp);
     getFits(result, *wf, pattern.c_str());
 
+    interp.setResult(result);
+}
+/**
+ * getall
+ *    Handles the command:
+ * 
+ * waveform getall name...
+ * 
+ * The result is a list of dicts for each waveform name dict keys:
+ *   *  name      Name of the waveform.
+ *   *  waveform  The result from the getWaveform
+ *   *  fits      The result from getFits with pattern *.
+ * 
+ * 
+ */
+void
+CWaveformCommand::getAll(CTCLInterpreter& interp, std::vector<CTCLObject>& objv) {
+    requireAtLeast(objv, 3, "getall needs at least one waveform name.");
+
+    int first = 2;    // Position of first waveform name in objv.
+    CTCLObject result;
+    result.Bind(interp);
+    for (int i = first; i < objv.size(); i++) {
+        std::string wfname(objv[i]);
+        CWaveform* wf = find(wfname.c_str());
+        if (!wf) {
+            std::stringstream strmsg;
+            strmsg << "There is no waveform defined named: " << wfname;
+            std::string msg = strmsg.str();
+            throw std::invalid_argument(msg);
+        }
+
+        CTCLObject waveform; waveform.Bind(interp);
+        CTCLObject fits;     fits.Bind(interp);
+        getWaveform(waveform, *wf);
+        getFits(fits, *wf);
+
+        // Make the dict list element and add it to result:
+
+        CTCLObject dict; dict.Bind(interp);
+        Tcl::DictPut(interp, dict, "name", objv[i]);
+        Tcl::DictPut(interp, dict, "waveform", waveform);
+        Tcl::DictPut(interp, dict, "fits", fits);
+
+        result += dict;
+    }
     interp.setResult(result);
 }
 /**

--- a/main/Core/CWaveformCommand.cpp
+++ b/main/Core/CWaveformCommand.cpp
@@ -20,7 +20,7 @@
  *         workers.
  */
 
-#include "CWaveformCommand.h"
+#include "CWaveformCommand.h"0, 
 #include "CWaveForm.h"
 #include "SpecTcl.h"
 
@@ -642,7 +642,7 @@ CWaveformCommand::listWaveform(CTCLObject& result, const CWaveform& wf) {
  *    Returns a list for the waveform  values. This is of the form:
  * 
  * \verbatim 
- *  {name {pts}}
+ *  {name {pts} rank}
  * \endverbatim
  * 
  * @param result - bound object to hold the result.

--- a/main/Core/CWaveformCommand.cpp
+++ b/main/Core/CWaveformCommand.cpp
@@ -20,7 +20,7 @@
  *         workers.
  */
 
-#include "CWaveformCommand.h"0, 
+#include "CWaveformCommand.h" 
 #include "CWaveForm.h"
 #include "SpecTcl.h"
 
@@ -536,37 +536,9 @@ CWaveformCommand::listFits(CTCLInterpreter& interp, std::vector<CTCLObject>& obj
 
     // List the fits and figure out the result:
 
-    auto listing = wf->listFits();
-
     CTCLObject result;
     result.Bind(interp);
-    for (auto& item : listing) {
-        // First, does the fit name match the pattern:
-
-        if (Tcl_StringMatch(item.first.c_str(), pattern.c_str())) {
-            
-            CTCLObject listitem;
-            listitem.Bind(interp);                // The dict we append.
-
-            // Put the fit name in the dict:
-
-            Tcl::DictPut(interp, listitem, "name", item.first.c_str());
-
-            // Marshall the fit points.
-            
-            auto& pts = wf->getFit(item.second);   // Now we have the fit points too.
-            CTCLObject ptlist;
-            ptlist.Bind(interp);
-            for (auto pt :pts) {
-                ptlist += pt;
-            }
-            // Add the fit points to the dict:
-
-            Tcl::DictPut(interp, listitem, "points", ptlist);
-
-            result += listitem;
-        }
-    }
+    getFits(result, *wf, pattern.c_str());
 
     interp.setResult(result);
 }
@@ -665,6 +637,46 @@ CWaveformCommand::getWaveform(CTCLObject& result, const CWaveform& wf) {
     result += points;
     result += myRank();              // MPI rank (0 if not MPI).
 
+}
+/**
+ * getFits
+ *    Returns the waveform's fit as a list of dicts {name fitname points {pt-list}}
+ * @param result - the object that will hold the resulting list of dicts 
+ * @param wf     - The waveform with fits to get.
+ * @param pattern - glob pattern that selects which named fits.
+ */
+void
+CWaveformCommand::getFits(CTCLObject& result, const CWaveform& wf, const char* pattern) {
+    auto listing = wf.listFits();
+    CTCLInterpreter& interp(*getInterpreter());
+
+    for (auto& item : listing) {
+        // First, does the fit name match the pattern:
+
+        if (Tcl_StringMatch(item.first.c_str(), pattern)) {
+            
+            CTCLObject listitem;
+            listitem.Bind(interp);                // The dict we append.
+
+            // Put the fit name in the dict:
+
+            Tcl::DictPut(interp, listitem, "name", item.first.c_str());
+
+            // Marshall the fit points.
+            
+            auto& pts = wf.getFit(item.second);   // Now we have the fit points too.
+            CTCLObject ptlist;
+            ptlist.Bind(interp);
+            for (auto pt :pts) {
+                ptlist += pt;
+            }
+            // Add the fit points to the dict:
+
+            Tcl::DictPut(interp, listitem, "points", ptlist);
+
+            result += listitem;
+        }
+    }
 }
 
 //////////////// MPI Wrapping:

--- a/main/Core/CWaveformCommand.h
+++ b/main/Core/CWaveformCommand.h
@@ -36,6 +36,7 @@ class CWaveform;
  * waveform metadata set wfname name value ...
  * waveform metadata get wfname ?name?
  * waveform resize name samples
+ * waveform fits name ?pattern?; #212
  * \endverbatim
  * 
  * Note it is not supported to delete waveforms.
@@ -74,6 +75,7 @@ protected:
     void metadataSet(CTCLInterpreter& interp,  std::vector<CTCLObject>& objv);
     void metadataGet(CTCLInterpreter& interp,  std::vector<CTCLObject>& objv);
     void resize(CTCLInterpreter& interp,  std::vector<CTCLObject>& objv);
+    void listFits(CTCLInterpreter& interp,  std::vector<CTCLObject>& objv); // Issue #212
 
     // Utilities
 private:

--- a/main/Core/CWaveformCommand.h
+++ b/main/Core/CWaveformCommand.h
@@ -84,6 +84,7 @@ private:
     void save(const CWaveform& wf);         //  Saves a constructed waveform.
     void listWaveform(CTCLObject& result, const CWaveform& wf);
     void getWaveform(CTCLObject& result, const CWaveform& wf);
+    void getFits(CTCLObject& result, const CWaveform& wf, const char* pattern = "*");
 };
 
 // MPI wrapper:

--- a/main/Core/CWaveformCommand.h
+++ b/main/Core/CWaveformCommand.h
@@ -33,6 +33,7 @@ class CWaveform;
  * waveform ?create? name samples
  * waveform list ?pattern?
  * waveform get name...
+ * waveform getall name...
  * waveform metadata set wfname name value ...
  * waveform metadata get wfname ?name?
  * waveform resize name samples
@@ -71,6 +72,7 @@ protected:
     void create(CTCLInterpreter& interp,  std::vector<CTCLObject>& objv, unsigned nameIdx);
     void list(CTCLInterpreter& interp,  std::vector<CTCLObject>& objv);
     void get(CTCLInterpreter& interp,  std::vector<CTCLObject>& objv);
+    void getAll(CTCLInterpreter& interp, std::vector<CTCLObject>& objv);
     void metadata(CTCLInterpreter& interp,  std::vector<CTCLObject>& objv);
     void metadataSet(CTCLInterpreter& interp,  std::vector<CTCLObject>& objv);
     void metadataGet(CTCLInterpreter& interp,  std::vector<CTCLObject>& objv);

--- a/main/Core/Makefile.am
+++ b/main/Core/Makefile.am
@@ -578,7 +578,7 @@ fribfiltertests_SOURCES=TestRunner.cpp fribfiltertests.cpp \
 	FRIBFilterFormatter.cpp FRIBFilterFormatter.h
 
 waveformtests_CXXFLAGS=$(commonTestCXXFLAGS)
-waveformtests_LDADD=$(commonTestLdFlags)
+waveformtests_LDADD=$(commonTestLdFlags) 
 waveformtests_SOURCES=TestRunner.cpp waveformtests.cpp wfdicttests.cpp \
 	wfapitests.cpp wfcmdtests.cpp wffittests.cpp
 

--- a/main/Core/Makefile.am
+++ b/main/Core/Makefile.am
@@ -580,7 +580,7 @@ fribfiltertests_SOURCES=TestRunner.cpp fribfiltertests.cpp \
 waveformtests_CXXFLAGS=$(commonTestCXXFLAGS)
 waveformtests_LDADD=$(commonTestLdFlags)
 waveformtests_SOURCES=TestRunner.cpp waveformtests.cpp wfdicttests.cpp \
-	wfapitests.cpp wfcmdtests.cpp
+	wfapitests.cpp wfcmdtests.cpp wffittests.cpp
 
 TESTS_ENVIRONMENT=LD_LIBRARY_PATH=$(ROOT_LIBRARY_DIR)
 TESTS =helpertests gateTests spectrumPkgTests displayInterfaceTests \

--- a/main/Core/wfcmdtests.cpp
+++ b/main/Core/wfcmdtests.cpp
@@ -31,6 +31,7 @@
 
 #include "SpecTcl.h"
 #include "CWaveForm.h"
+#include <TclDict.h>
 #include <tcl.h>
 
 class WFCmdTests : public CppUnit::TestFixture {
@@ -80,6 +81,18 @@ class WFCmdTests : public CppUnit::TestFixture {
     CPPUNIT_TEST(fits_6);   // The fit list is correct.
     CPPUNIT_TEST(fits_7);   // pattern defaults to *
 
+    // test waveform getall sub-command (Issue #212).
+
+    CPPUNIT_TEST(getall_1);  // Too few parameters.
+    CPPUNIT_TEST(getall_2);  // One waveform, no fits.
+    CPPUNIT_TEST(getall_3);  // One waveform 1 fit.
+    CPPUNIT_TEST(getall_4);  // One waveform more than 1 fit.
+    CPPUNIT_TEST(getall_5);  // Two waveforms neither has fits.
+    CPPUNIT_TEST(getall_6);  // Two waveforms first has a fit.
+    CPPUNIT_TEST(getall_7);  // Two waveforms second has two fits.
+    CPPUNIT_TEST(getall_8);  // Two waveforms first as a fit second has two fits.
+    CPPUNIT_TEST(getall_9);  // no such waveform error.
+
     CPPUNIT_TEST_SUITE_END();
 
     // test methods
@@ -127,6 +140,19 @@ private:
     void fits_5();
     void fits_6();
     void fits_7();
+
+    void getall_1();
+    void getall_2();
+    void getall_3();
+    void getall_4();
+    void getall_5();
+    void getall_6();
+    void getall_7();
+    void getall_8();
+    void getall_9();
+
+private:    // utilities
+    std::pair<CWaveform*, CWaveform*>  makeWfPair();
 // Test objects:
 private:
     CTCLInterpreter* m_pInterp;
@@ -732,7 +758,6 @@ WFCmdTests::fits_5() {
     CTCLObject lresult; 
     lresult.Bind(m_pInterp);
     lresult = std::string(result);
-    std::cerr << result << std::endl;
     EQ(1, lresult.llength());
 }
 
@@ -787,4 +812,85 @@ std::string result;
     lresult = std::string(result);
     
     EQ(1, lresult.llength());
+}
+// Tests for the getall subcommand.  They use the following utility:
+
+std::pair<CWaveform*, CWaveform*> 
+WFCmdTests::makeWfPair() {
+    CWaveform wf1("a", 10);   // Firs is before the second.
+    CWaveform wf2("b", 10);
+
+    SpecTcl::getInstance()->addWaveform(wf1);
+    SpecTcl::getInstance()->addWaveform(wf2);
+
+    auto p1 = SpecTcl::getInstance()->findWaveform("a");
+    auto p2 = SpecTcl::getInstance()->findWaveform("b");
+
+    return {p1, p2};
+}
+
+void
+WFCmdTests::getall_1() {
+    /// Too few parameters, needs at least one waveform.
+
+    CPPUNIT_ASSERT_THROW(
+        m_pInterp->GlobalEval("spectcl::serial::waveform getall"),
+        CTCLException
+    );
+}
+void
+WFCmdTests::getall_2() {
+    makeWfPair();               // NO fits so I don't need the ptr.
+    std::string result;
+    CPPUNIT_ASSERT_NO_THROW(
+        result = m_pInterp->GlobalEval("spectcl::serial::waveform getall a");
+    );
+    CTCLObject oResult; oResult.Bind(m_pInterp); oResult = result;
+
+    // There should only be one element:
+    EQ(1, oResult.llength());
+    // It should describe "a" and have a 10 pt waveform:
+
+    CTCLObject desc = oResult.lindex(0); desc.Bind(m_pInterp);
+    std::string wfName = Tcl::DictGetAsStr(*m_pInterp, desc, "name");
+    EQ(std::string("a"), wfName);
+
+    CTCLObject waveform = Tcl::DictGet(*m_pInterp, desc, "waveform");   // waveform is bound.
+    EQ(3, waveform.llength());
+    EQ(std::string("a"), std::string(waveform.lindex(0)));
+    CTCLObject trace = waveform.lindex(1); trace.Bind(m_pInterp);
+    EQ(10, trace.llength());                 // Correct # of points.
+
+    CTCLObject fits = Tcl::DictGet(*m_pInterp, desc, "fits");
+    EQ(0, fits.llength());                         // No fits.
+
+
+}
+void
+WFCmdTests::getall_3() {
+    
+}
+void
+WFCmdTests::getall_4() {
+    
+}
+void
+WFCmdTests::getall_5() {
+    
+}
+void
+WFCmdTests::getall_6() {
+    
+}
+void
+WFCmdTests::getall_7() {
+    
+}
+void
+WFCmdTests::getall_8() {
+    
+}
+void
+WFCmdTests::getall_9() {
+    
 }

--- a/main/Core/wfcmdtests.cpp
+++ b/main/Core/wfcmdtests.cpp
@@ -868,6 +868,41 @@ WFCmdTests::getall_2() {
 }
 void
 WFCmdTests::getall_3() {
+    auto wfs = makeWfPair();
+    // add a fit to the first one:
+
+    wfs.first->addFit("afit");
+
+    std::string result;
+    CPPUNIT_ASSERT_NO_THROW(
+        result = m_pInterp->GlobalEval("spectcl::serial::waveform getall a");
+    );
+    CTCLObject oResult; oResult.Bind(m_pInterp); oResult = result;
+
+    // There should only be one element:
+    EQ(1, oResult.llength());
+    // It should describe "a" and have a 10 pt waveform:
+
+    CTCLObject desc = oResult.lindex(0); desc.Bind(m_pInterp);
+    std::string wfName = Tcl::DictGetAsStr(*m_pInterp, desc, "name");
+    EQ(std::string("a"), wfName);
+
+    CTCLObject waveform = Tcl::DictGet(*m_pInterp, desc, "waveform");   // waveform is bound.
+    EQ(3, waveform.llength());
+    EQ(std::string("a"), std::string(waveform.lindex(0)));
+    CTCLObject trace = waveform.lindex(1); trace.Bind(m_pInterp);
+    EQ(10, trace.llength());                 // Correct # of points.
+
+    CTCLObject fits = Tcl::DictGet(*m_pInterp, desc, "fits");
+    EQ(1, fits.llength());
+    CTCLObject fit = fits.lindex(0);   // name "afit", points 10 element list.
+    fit.Bind(m_pInterp);
+
+    EQ(std::string("afit"), Tcl::DictGetAsStr(*m_pInterp, fit, "name"));
+    
+    CTCLObject points = Tcl::DictGet(*m_pInterp, fit, "points");
+    points.Bind(m_pInterp);
+    EQ(10, points.llength());
     
 }
 void

--- a/main/Core/wfcmdtests.cpp
+++ b/main/Core/wfcmdtests.cpp
@@ -69,6 +69,17 @@ class WFCmdTests : public CppUnit::TestFixture {
     CPPUNIT_TEST(resize_2);
     CPPUNIT_TEST(resize_3);
     CPPUNIT_TEST(resize_4);
+
+    // Tests fits subcommand (ISsue #212)
+
+    CPPUNIT_TEST(fits_1);   // too few params.
+    CPPUNIT_TEST(fits_2);   // too many params.
+    CPPUNIT_TEST(fits_3);   // no such waveform.
+    CPPUNIT_TEST(fits_4);   // No fits present.
+    CPPUNIT_TEST(fits_5);   // There's a fit.   
+    CPPUNIT_TEST(fits_6);   // The fit list is correct.
+    CPPUNIT_TEST(fits_7);   // pattern defaults to *
+
     CPPUNIT_TEST_SUITE_END();
 
     // test methods
@@ -108,6 +119,14 @@ private:
     void resize_2();
     void resize_3();
     void resize_4();
+
+    void fits_1();
+    void fits_2();
+    void fits_3();
+    void fits_4();
+    void fits_5();
+    void fits_6();
+    void fits_7();
 // Test objects:
 private:
     CTCLInterpreter* m_pInterp;
@@ -641,4 +660,131 @@ WFCmdTests::resize_4() {
         m_pInterp->GlobalEval("spectcl::serial::waveform resize test"),
         CTCLException
     );   
+}
+
+// Tests for fits (Issue #212)
+
+void 
+WFCmdTests::fits_1() {
+    // Fits needs a waveform.
+    CPPUNIT_ASSERT_THROW(
+        m_pInterp->GlobalEval("spectcl::serial::waveform fits"),
+        CTCLException
+    );
+}
+
+void 
+WFCmdTests::fits_2() {
+    // there's a waveform, but too many parameters:
+
+    CWaveform wf("test", 100);
+    SpecTcl::getInstance()->addWaveform(wf);
+
+    CPPUNIT_ASSERT_THROW(
+        m_pInterp->GlobalEval("spectcl::serial::waveform fits test * extra-junk"),
+        CTCLException
+    );
+}
+
+void 
+WFCmdTests::fits_3() {
+    // Incorrect fit name:
+
+    CWaveform wf("test", 100);
+    SpecTcl::getInstance()->addWaveform(wf);
+
+    CPPUNIT_ASSERT_THROW(
+        m_pInterp->GlobalEval("spectcl::serial::waveform fits tests *"),
+        CTCLException
+    );
+}
+
+void 
+WFCmdTests::fits_4() {
+    std::string result;
+
+    CWaveform wf("test", 100);
+    SpecTcl::getInstance()->addWaveform(wf);
+
+    CPPUNIT_ASSERT_NO_THROW(
+       result = m_pInterp->GlobalEval("spectcl::serial::waveform fits test *")
+    );
+
+    CTCLObject lresult; 
+    lresult.Bind(m_pInterp);
+    lresult = std::string(result);
+
+    EQ(0, lresult.llength());
+}
+
+void 
+WFCmdTests::fits_5() {
+    std::string result;
+
+    CWaveform wf("test", 100);
+    wf.addFit("Afit");
+    SpecTcl::getInstance()->addWaveform(wf);
+
+    CPPUNIT_ASSERT_NO_THROW(
+        result = m_pInterp->GlobalEval("spectcl::serial::waveform fits test *")
+    );
+
+    CTCLObject lresult; 
+    lresult.Bind(m_pInterp);
+    lresult = std::string(result);
+    std::cerr << result << std::endl;
+    EQ(1, lresult.llength());
+}
+
+void 
+WFCmdTests::fits_6() {
+    std::string result;
+
+    CWaveform wf("test", 100);
+    wf.addFit("Afit");
+    SpecTcl::getInstance()->addWaveform(wf);
+
+    CPPUNIT_ASSERT_NO_THROW(
+        result = m_pInterp->GlobalEval("spectcl::serial::waveform fits test *")
+    );
+
+    CTCLObject lresult; 
+    lresult.Bind(m_pInterp);
+    lresult = std::string(result);
+    
+    // Simplify dict handling it's alist of name value name value....
+    CTCLObject def; def.Bind(m_pInterp); def = lresult.lindex(0);  // The definition.
+    EQ(4, def.llength());                                         // namekey name pointskey points
+    EQ(std::string("name"), std::string(def.lindex(0)));           // Name key.    
+    EQ(std::string("Afit"), std::string(def.lindex(1)));            // name value.
+    EQ(std::string("points"), std::string(def.lindex(2)));       // points key.
+
+    CTCLObject pts; pts.Bind(m_pInterp); pts = def.lindex(3);    // List of points.
+
+    EQ(100, pts.llength());
+
+    // All the points are "0.0"
+
+    auto points = pts.getListElements();
+    for (auto& p : points) {
+        EQ(std::string("0.0"), std::string(p));
+    }
+}
+void
+WFCmdTests::fits_7() {
+std::string result;
+
+    CWaveform wf("test", 100);
+    wf.addFit("Afit");
+    SpecTcl::getInstance()->addWaveform(wf);
+
+    CPPUNIT_ASSERT_NO_THROW(
+        result = m_pInterp->GlobalEval("spectcl::serial::waveform fits test *")
+    );
+
+    CTCLObject lresult; 
+    lresult.Bind(m_pInterp);
+    lresult = std::string(result);
+    
+    EQ(1, lresult.llength());
 }

--- a/main/Core/wfcmdtests.cpp
+++ b/main/Core/wfcmdtests.cpp
@@ -907,25 +907,166 @@ WFCmdTests::getall_3() {
 }
 void
 WFCmdTests::getall_4() {
+    auto wfs = makeWfPair();
+    wfs.first->addFit("bfit");
+    wfs.first->addFit("afit");   // Should come out in alpha order, (Whilte box).
+
+    std::string result;
+    CPPUNIT_ASSERT_NO_THROW(
+        result = m_pInterp->GlobalEval("spectcl::serial::waveform getall a")
+    );
+
+    CTCLObject oResult; oResult.Bind(m_pInterp); oResult = result;
     
+    CTCLObject desc = oResult.lindex(0);  desc.Bind(m_pInterp);
+
+    // Cut to the fits:
+
+    CTCLObject fits = Tcl::DictGet(*m_pInterp, desc, "fits");
+    EQ(2, fits.llength());
+
+    CTCLObject fit1 = fits.lindex(0);
+    CTCLObject fit2 = fits.lindex(1);
+    EQ(std::string("afit"), Tcl::DictGetAsStr(*m_pInterp, fit1, "name"));
+    EQ(std::string("bfit"), Tcl::DictGetAsStr(*m_pInterp, fit2, "name"));
+
+
 }
 void
 WFCmdTests::getall_5() {
-    
+    auto wfs = makeWfPair();
+
+    std::string result;
+    CPPUNIT_ASSERT_NO_THROW(
+
+        result = m_pInterp->GlobalEval("spectcl::serial::waveform getall a b")
+    );
+
+    // There should be two waveforms verify the names and that there are no fits in either:
+
+    CTCLObject oResult; oResult.Bind(m_pInterp); oResult = result;
+
+    EQ(2, oResult.llength());
+    CTCLObject d1 = oResult.lindex(0); 
+    CTCLObject d2 = oResult.lindex(1);
+
+    EQ(std::string("a"), Tcl::DictGetAsStr(*m_pInterp, d1, "name"));
+    EQ(std::string("b"), Tcl::DictGetAsStr(*m_pInterp, d2, "name"));
+
+    CTCLObject f1 = Tcl::DictGet(*m_pInterp, d1, "fits");
+    EQ(0, f1.llength());
+
+    CTCLObject f2 = Tcl::DictGet(*m_pInterp, d2, "fits");
+    EQ(0, f2.llength());
 }
 void
 WFCmdTests::getall_6() {
-    
+    auto wfs = makeWfPair();
+    wfs.first->addFit("fit");
+std::string result;
+    CPPUNIT_ASSERT_NO_THROW(
+
+        result = m_pInterp->GlobalEval("spectcl::serial::waveform getall a b")
+    );
+
+    // There should be two waveforms verify the names and that there are no fits in either:
+
+    CTCLObject oResult; oResult.Bind(m_pInterp); oResult = result;
+
+    EQ(2, oResult.llength());
+    CTCLObject d1 = oResult.lindex(0); 
+    CTCLObject d2 = oResult.lindex(1);
+
+    EQ(std::string("a"), Tcl::DictGetAsStr(*m_pInterp, d1, "name"));
+    EQ(std::string("b"), Tcl::DictGetAsStr(*m_pInterp, d2, "name"));
+
+    CTCLObject f1 = Tcl::DictGet(*m_pInterp, d1, "fits");
+    EQ(1, f1.llength());
+
+    CTCLObject f2 = Tcl::DictGet(*m_pInterp, d2, "fits");
+    EQ(0, f2.llength());
 }
+
+
 void
 WFCmdTests::getall_7() {
+    auto wfs = makeWfPair();
+    wfs.second->addFit("fit2");
+    wfs.second->addFit("fit1");
+
+    std::string result;
+    CPPUNIT_ASSERT_NO_THROW(
+
+        result = m_pInterp->GlobalEval("spectcl::serial::waveform getall a b")
+    );
+
+    // There should be two waveforms verify the names and that there are no fits in either:
+
+    CTCLObject oResult; oResult.Bind(m_pInterp); oResult = result;
+
+    EQ(2, oResult.llength());
+    CTCLObject d1 = oResult.lindex(0); 
+    CTCLObject d2 = oResult.lindex(1);
+
+    EQ(std::string("a"), Tcl::DictGetAsStr(*m_pInterp, d1, "name"));
+    EQ(std::string("b"), Tcl::DictGetAsStr(*m_pInterp, d2, "name"));
+
+    CTCLObject f1 = Tcl::DictGet(*m_pInterp, d1, "fits");
+    EQ(0, f1.llength());
+
+    CTCLObject f2 = Tcl::DictGet(*m_pInterp, d2, "fits");
+    EQ(2, f2.llength());
+
+    // fit names in alpha order:
+
+    CTCLObject fit1 = f2.lindex(0);
+    fit1.Bind(m_pInterp);
+    EQ(std::string("fit1"), Tcl::DictGetAsStr(*m_pInterp, fit1, "name"));
     
+    CTCLObject fit2 = f2.lindex(1);
+    fit2.Bind(m_pInterp);
+    EQ(std::string("fit2"), Tcl::DictGetAsStr(*m_pInterp, fit2, "name"));
 }
+
 void
 WFCmdTests::getall_8() {
-    
+    auto wfs = makeWfPair();
+    wfs.first->addFit("fit1.1");
+    wfs.second->addFit("fit1.2");
+    wfs.second->addFit("fit2.2");
+
+    CTCLObject oResult; oResult.Bind(m_pInterp);
+    oResult = m_pInterp->GlobalEval("spectcl::serial::waveform getall a b");
+
+    CTCLObject d1 = oResult.lindex(0); d1.Bind(m_pInterp);
+    CTCLObject d2 = oResult.lindex(1); d2.Bind(m_pInterp);
+
+    // There' one  fit in d1:
+
+    CTCLObject fitsa = Tcl::DictGet(*m_pInterp, d1, "fits");
+    EQ(1, fitsa.llength());
+    CTCLObject fita = fitsa.lindex(0);
+    EQ(std::string("fit1.1"), Tcl::DictGetAsStr(*m_pInterp, fita, "name"));
+
+    // there's two fits in d1:
+
+    CTCLObject fitsb = Tcl::DictGet(*m_pInterp, d2, "fits");
+    EQ(2,  fitsb.llength());
+
+    CTCLObject fitb1 = fitsb.lindex(0);
+    CTCLObject fitb2 = fitsb.lindex(1);
+
+    EQ(std::string("fit1.2"), Tcl::DictGetAsStr(*m_pInterp, fitb1, "name"));
+    EQ(std::string("fit2.2"), Tcl::DictGetAsStr(*m_pInterp, fitb2, "name"));
+
+
 }
 void
 WFCmdTests::getall_9() {
+
+    CPPUNIT_ASSERT_THROW(
+        m_pInterp->GlobalEval("spectcl::serial::waveform getall nosuch"),
+        CTCLException
+    );
     
 }

--- a/main/Core/wffittests.cpp
+++ b/main/Core/wffittests.cpp
@@ -30,6 +30,8 @@
 #include <CDuplicateSingleton.h>
 #include <CNoSuchObjectException.h>
 
+#include <math.h>
+
 class WFFitTests : public CppUnit::TestFixture {
 CPPUNIT_TEST_SUITE(WFFitTests);
 CPPUNIT_TEST(nofits_1);
@@ -44,6 +46,10 @@ CPPUNIT_TEST(get_1);
 CPPUNIT_TEST(get_2);
 CPPUNIT_TEST(get_3);
 CPPUNIT_TEST(get_4);
+CPPUNIT_TEST(fill_1);
+CPPUNIT_TEST(fill_2);
+CPPUNIT_TEST(fill_3);
+CPPUNIT_TEST(fill_4);
 CPPUNIT_TEST_SUITE_END();
 
 private: 
@@ -67,9 +73,16 @@ protected:
     void get_3();             // By name.
     void get_4();
 
+    void fill_1();           // by number.
+    void fill_2();
+
+    void fill_3();           // by name.
+    void fill_4();
+
     // utilities (not tests)
 
     void add();     // Add fit named "afit"
+    CWaveform::Fit_t makeFit();
 public:
 
     void setUp() {                  // Probably don't need this but whatever.
@@ -240,6 +253,70 @@ WFFitTests::get_4() {
 }
 
 
+// Tests for fillFit.  
+
+void
+WFFitTests::fill_1() {
+    // FIll existing by number
+
+    add();
+    size_t id = m_pTestwf->findFit("afit");
+    auto fit = makeFit();
+
+    CPPUNIT_ASSERT_NO_THROW(
+        m_pTestwf->fillFit(id, fit.data())
+    );
+
+    // Now let's be sure the points match:
+
+    auto& filledFit = m_pTestwf->getFit(id);
+    for (int i = 0; i < fit.size(); i++) {
+        EQ(fit[i], filledFit[i]);
+    }
+}
+void
+WFFitTests::fill_2() {
+    // fill nonexistent by number:
+
+    add();
+    auto fit = makeFit();
+    CPPUNIT_ASSERT_THROW(
+        m_pTestwf->fillFit(1245, fit.data()),
+        CNoSuchObjectException
+    );
+}
+
+void
+WFFitTests::fill_3() {
+    // Fill existing by name.
+
+    add();
+    auto fit = makeFit();
+    size_t id;
+    CPPUNIT_ASSERT_NO_THROW(
+        id = m_pTestwf->fillFit("afit", fit.data())
+    );
+    // returned Id is correct:
+
+    EQ(id, m_pTestwf->findFit("afit"));
+
+    // FIt contents are corret;
+
+    auto& filledFit = m_pTestwf->getFit(id);
+    for (int i = 0; i < fit.size(); i++) {
+        EQ(fit[i], filledFit[i]);
+    }
+}
+
+void
+WFFitTests::fill_4() {
+    add();
+    auto fit = makeFit();
+    CPPUNIT_ASSERT_THROW(
+        m_pTestwf->fillFit("nosuchfit", fit.data()),
+        CNoSuchObjectException
+    );
+}
 ////////////////////// Utility methods:
 
 void
@@ -248,3 +325,22 @@ WFFitTests::add() {
 
     m_pTestwf->addFit("afit");
 }
+
+CWaveform::Fit_t
+WFFitTests::makeFit() {
+    auto pts = m_pTestwf->size();    // # of poits.
+
+    // We'll make a full cycle sin wave (roughly) 
+    // scaled by 100.0.
+
+    double step = (2.0*3.14159)/double(pts); // 2pi / pts.
+
+    CWaveform::Fit_t result;            // Really a vector.
+    for (int i =0; i < pts; i++) {
+        result.push_back(100.0 * sin(double(i)*step));
+    }
+    return result;
+
+}
+
+

--- a/main/Core/wffittests.cpp
+++ b/main/Core/wffittests.cpp
@@ -1,0 +1,66 @@
+/*
+    This software is Copyright by the Board of Trustees of Michigan
+    State University (c) Copyright 2017.
+
+    You may use this software under the terms of the GNU public license
+    (GPL).  The terms of this license are described at:
+
+     http://www.gnu.org/licenses/gpl.txt
+
+     Authors:
+             Ron Fox
+             Giordano Cerriza
+	     NSCL
+	     Michigan State University
+	     East Lansing, MI 48824-1321
+*/
+
+/** @file:  wffittests.cpp
+ *  @brief: Test the waveform fit extensions for Issue #212
+ */
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/Asserter.h>
+#include "Asserts.h"
+
+#define private public
+#include "CWaveForm.h"
+#undef private
+
+
+#include <CDuplicateSingleton.h>
+#include <CNoSuchObjectException.h>
+
+class WFFitTests : public CppUnit::TestFixture {
+CPPUNIT_TEST_SUITE(WFFitTests);
+CPPUNIT_TEST(nofits_1);
+CPPUNIT_TEST_SUITE_END();
+
+private: 
+    CWaveform* m_pTestwf;
+
+protected:
+    void nofits_1();
+public:
+
+    void setUp() {                  // Probably don't need this but whatever.
+        CWaveform::m_idIndex = 0;   
+        m_pTestwf = new CWaveform("someWaveform", 100);
+    }
+    void teardown() {
+        delete m_pTestwf;
+        m_pTestwf = nullptr;
+    }
+
+};
+CPPUNIT_TEST_SUITE_REGISTRATION(WFFitTests);
+
+
+///////////////////////////// The tests //////////////////
+
+// If there are no fits, the dictionary and fit vector are empty:
+
+void
+WFFitTests::nofits_1() {
+    EQ(size_t(0), m_pTestwf->m_fitDictionary.size());
+    EQ(size_t(0), m_pTestwf->m_fits.size());
+}

--- a/main/Core/wffittests.cpp
+++ b/main/Core/wffittests.cpp
@@ -33,6 +33,10 @@
 class WFFitTests : public CppUnit::TestFixture {
 CPPUNIT_TEST_SUITE(WFFitTests);
 CPPUNIT_TEST(nofits_1);
+CPPUNIT_TEST(add_1);
+CPPUNIT_TEST(add_2);
+CPPUNIT_TEST(add_3);
+CPPUNIT_TEST(add_4);
 CPPUNIT_TEST_SUITE_END();
 
 private: 
@@ -40,6 +44,11 @@ private:
 
 protected:
     void nofits_1();
+
+    void add_1();
+    void add_2();
+    void add_3();
+    void add_4();
 public:
 
     void setUp() {                  // Probably don't need this but whatever.
@@ -63,4 +72,51 @@ void
 WFFitTests::nofits_1() {
     EQ(size_t(0), m_pTestwf->m_fitDictionary.size());
     EQ(size_t(0), m_pTestwf->m_fits.size());
+}
+
+// Tests to add fits:
+
+void 
+WFFitTests::add_1() {
+    // Adding a fit makes the dictionary and vector size 1:
+
+    m_pTestwf->addFit("afit");
+    EQ(size_t(1), m_pTestwf->m_fitDictionary.size());
+    EQ(size_t(1), m_pTestwf->m_fits.size());
+}
+void
+WFFitTests::add_2() {
+    // adding a fit puts it in the dictionary.
+
+    m_pTestwf->addFit("afit");
+    ASSERT(m_pTestwf->m_fitDictionary.find("afit") != m_pTestwf->m_fitDictionary.end());
+}
+void
+WFFitTests::add_3() {
+     // Adding a fit puts it in the vector with the correct id and size:
+
+     m_pTestwf->addFit("afit");
+     size_t n = m_pTestwf->m_fitDictionary["afit"];
+     EQ(size_t(0), n);
+     EQ(size_t(100), m_pTestwf->m_fits[0].size());
+}
+
+void
+WFFitTests::add_4() {
+    // Adding a duplicate fit throws CDuplicateSingleton
+
+    m_pTestwf->addFit("afit");
+    CPPUNIT_ASSERT_THROW(
+        m_pTestwf->addFit("afit"),
+        CDuplicateSingleton
+    );
+    // but adding a different one does not:
+
+    CPPUNIT_ASSERT_NO_THROW(
+        m_pTestwf->addFit("anotherfit")
+    );
+    // and that makes 2 dictionary and vector entries:
+
+    EQ(size_t(2), m_pTestwf->m_fitDictionary.size());
+    EQ(size_t(2), m_pTestwf->m_fits.size());
 }

--- a/main/Core/wffittests.cpp
+++ b/main/Core/wffittests.cpp
@@ -37,6 +37,9 @@ CPPUNIT_TEST(add_1);
 CPPUNIT_TEST(add_2);
 CPPUNIT_TEST(add_3);
 CPPUNIT_TEST(add_4);
+CPPUNIT_TEST(find_1);
+CPPUNIT_TEST(find_2);
+CPPUNIT_TEST(find_3);
 CPPUNIT_TEST_SUITE_END();
 
 private: 
@@ -49,6 +52,15 @@ protected:
     void add_2();
     void add_3();
     void add_4();
+
+    void find_1();
+    void find_2();
+    void find_3();
+
+
+    // utilities (not tests)
+
+    void add();     // Add fit named "afit"
 public:
 
     void setUp() {                  // Probably don't need this but whatever.
@@ -80,7 +92,7 @@ void
 WFFitTests::add_1() {
     // Adding a fit makes the dictionary and vector size 1:
 
-    m_pTestwf->addFit("afit");
+    add();
     EQ(size_t(1), m_pTestwf->m_fitDictionary.size());
     EQ(size_t(1), m_pTestwf->m_fits.size());
 }
@@ -88,14 +100,14 @@ void
 WFFitTests::add_2() {
     // adding a fit puts it in the dictionary.
 
-    m_pTestwf->addFit("afit");
+    add();
     ASSERT(m_pTestwf->m_fitDictionary.find("afit") != m_pTestwf->m_fitDictionary.end());
 }
 void
 WFFitTests::add_3() {
      // Adding a fit puts it in the vector with the correct id and size:
 
-     m_pTestwf->addFit("afit");
+     add();
      size_t n = m_pTestwf->m_fitDictionary["afit"];
      EQ(size_t(0), n);
      EQ(size_t(100), m_pTestwf->m_fits[0].size());
@@ -105,7 +117,7 @@ void
 WFFitTests::add_4() {
     // Adding a duplicate fit throws CDuplicateSingleton
 
-    m_pTestwf->addFit("afit");
+    add();
     CPPUNIT_ASSERT_THROW(
         m_pTestwf->addFit("afit"),
         CDuplicateSingleton
@@ -119,4 +131,61 @@ WFFitTests::add_4() {
 
     EQ(size_t(2), m_pTestwf->m_fitDictionary.size());
     EQ(size_t(2), m_pTestwf->m_fits.size());
+}
+
+// Tests for the find method:
+
+void
+WFFitTests::find_1() {
+    // Can't find what's not there.
+
+    add();
+    CPPUNIT_ASSERT_THROW(
+        m_pTestwf->findFit("nosuch"),
+        CNoSuchObjectException
+
+    );
+}
+void
+WFFitTests::find_2() {
+    // Can find one it it's there:
+
+    add();
+    size_t  id;
+    CPPUNIT_ASSERT_NO_THROW(
+        id = m_pTestwf->findFit("afit")
+    );
+    EQ(id, m_pTestwf->m_fitDictionary["afit"]);
+}
+void
+WFFitTests::find_3() {
+    // We can find the correct one when there are several present.
+
+    add();                   //"afit"
+    m_pTestwf->addFit("another");
+
+    size_t id1, id2;
+    CPPUNIT_ASSERT_NO_THROW(
+        id1 = m_pTestwf->findFit("afit")
+    );
+    CPPUNIT_ASSERT_NO_THROW(
+        id2 = m_pTestwf->findFit("another")
+    );
+
+    // Correct indices "afit" is 0, "another ' is 1.. but
+    // let's get it from the map:
+
+    ASSERT(id1 != id2);   // They are distinct.
+    EQ(id1, m_pTestwf->m_fitDictionary["afit"]);
+    EQ(id2, m_pTestwf->m_fitDictionary["another"]);
+}
+
+
+////////////////////// Utility methods:
+
+void
+WFFitTests::add() {
+    // Add a fit named "afit"
+
+    m_pTestwf->addFit("afit");
 }

--- a/main/Core/wffittests.cpp
+++ b/main/Core/wffittests.cpp
@@ -40,6 +40,10 @@ CPPUNIT_TEST(add_4);
 CPPUNIT_TEST(find_1);
 CPPUNIT_TEST(find_2);
 CPPUNIT_TEST(find_3);
+CPPUNIT_TEST(get_1);
+CPPUNIT_TEST(get_2);
+CPPUNIT_TEST(get_3);
+CPPUNIT_TEST(get_4);
 CPPUNIT_TEST_SUITE_END();
 
 private: 
@@ -57,6 +61,11 @@ protected:
     void find_2();
     void find_3();
 
+    void get_1();              // By number.
+    void get_2();
+
+    void get_3();             // By name.
+    void get_4();
 
     // utilities (not tests)
 
@@ -178,6 +187,56 @@ WFFitTests::find_3() {
     ASSERT(id1 != id2);   // They are distinct.
     EQ(id1, m_pTestwf->m_fitDictionary["afit"]);
     EQ(id2, m_pTestwf->m_fitDictionary["another"]);
+}
+
+// Tests for both getFit methods. 
+
+void
+WFFitTests::get_1() {
+    // Get existing fit by number:
+    add();
+
+    CPPUNIT_ASSERT_NO_THROW(
+        auto& fit = m_pTestwf->getFit(m_pTestwf->m_fitDictionary["afit"])
+    );
+    // I don't think fit is in scope any more but we want to check that this is the 
+    // correct fit:
+
+    auto& fit = m_pTestwf->getFit(m_pTestwf->m_fitDictionary["afit"]);
+    const CWaveform::Fit_t* actual = &(m_pTestwf->m_fits[m_pTestwf->m_fitDictionary["afit"]]);
+    EQ(&fit, actual);
+}
+
+void 
+WFFitTests::get_2() {
+    // Get nonexistinug fit by number throws:
+    add();
+    CPPUNIT_ASSERT_THROW(
+        m_pTestwf->getFit(1234),
+        CNoSuchObjectException
+    );
+}
+
+void 
+WFFitTests::get_3() {
+    // Get by name existing:
+    add();
+    CPPUNIT_ASSERT_NO_THROW(
+        auto& fit = m_pTestwf->getFit("afit")
+    );
+    auto& fit = m_pTestwf->getFit("afit");
+    const CWaveform::Fit_t* actual = &(m_pTestwf->m_fits[m_pTestwf->m_fitDictionary["afit"]]);
+    EQ(&fit, actual);
+
+}
+void
+WFFitTests::get_4() {
+    // nonexistent by name throws.
+    add();
+    CPPUNIT_ASSERT_THROW(
+        m_pTestwf->getFit("nosuchfit"),
+        CNoSuchObjectException
+    );
 }
 
 

--- a/main/Core/wffittests.cpp
+++ b/main/Core/wffittests.cpp
@@ -50,6 +50,9 @@ CPPUNIT_TEST(fill_1);
 CPPUNIT_TEST(fill_2);
 CPPUNIT_TEST(fill_3);
 CPPUNIT_TEST(fill_4);
+CPPUNIT_TEST(list_1);
+CPPUNIT_TEST(list_2);
+CPPUNIT_TEST(list_3);
 CPPUNIT_TEST_SUITE_END();
 
 private: 
@@ -78,6 +81,10 @@ protected:
 
     void fill_3();           // by name.
     void fill_4();
+
+    void list_1();
+    void list_2();
+    void list_3();
 
     // utilities (not tests)
 
@@ -316,6 +323,51 @@ WFFitTests::fill_4() {
         m_pTestwf->fillFit("nosuchfit", fit.data()),
         CNoSuchObjectException
     );
+}
+
+// Tests for listFits:
+
+void 
+WFFitTests::list_1() {
+    // There's nothing to list:
+
+    EQ(size_t(0), m_pTestwf->listFits().size());
+}
+void
+WFFitTests::list_2() {
+    // There's our single fit:
+
+    add();
+    auto listing = m_pTestwf->listFits();
+    EQ(size_t(1), listing.size());
+    EQ(std::string("afit"), listing.at(0).first);
+    EQ(size_t(0), listing.at(0).second);
+}
+
+void
+WFFitTests::list_3() {
+    // A few fits to add.. note they'll come out in alpha order
+    // We're going to add them backwards.
+    // so these are pairs of names and anticipatd indices.
+    std::vector<std::pair<std::string, size_t>> fits = {
+        {"aaa", 4}, {"bbb", 3}, {"cccc", 2}, {"dddd", 1}, 
+        {"zzzz", 0}
+    };
+    // Add the fits in reverse order.
+    for (auto p = fits.rbegin(); p != fits.rend(); ++p) {
+        m_pTestwf->addFit(p->first.c_str());
+    }
+    // a bit of white box here, they should come out in alpha order
+    // because this is iterating the fit map.
+
+    auto listing = m_pTestwf->listFits();    
+    EQ(fits.size(), listing.size());    //should have only and all of the fits I added.
+
+    for (int i =0; i < fits.size(); i++) {
+        EQ(fits.at(i).first, listing.at(i).first);
+        EQ(fits.at(i).second, listing.at(i).second);
+    }
+
 }
 ////////////////////// Utility methods:
 

--- a/main/SpecTcl/MySpecTclApp.cpp
+++ b/main/SpecTcl/MySpecTclApp.cpp
@@ -27,6 +27,8 @@ static const char* Copyright = "(C) Copyright Michigan State University 2008, Al
 #include "TCLAnalyzer.h"
 #include <Event.h>
 #include <TreeParameter.h>
+#include <SpecTcl.h>
+#include <CWaveForm.h>
 
 #ifdef HAVE_STD_NAMESPACE
 using namespace std;
@@ -82,13 +84,21 @@ MyParameters vars = {
 
 class CFixedEventUnpacker : public  CEventProcessor
 {
+private:
+  CWaveform* m_pWf;
 public:
   virtual Bool_t operator()(const Address_t pEvent,
                 CEvent&         rEvent,
                 CAnalyzer&      rAnalyzer,
                 CBufferDecoder& rDecoder);
-};
+Bool_t OnEventSourceOpen(std::string name) {
+  m_pWf = SpecTcl::getInstance()->findWaveform("test");
+  // If there are no fits, make  a couple of them.
 
+  return kfTRUE;
+}
+
+};
 Bool_t
 CFixedEventUnpacker::operator()(const Address_t pEvent,
                 CEvent&         rEvent,
@@ -117,6 +127,29 @@ CFixedEventUnpacker::operator()(const Address_t pEvent,
     event.raw[param] = *p++;
     nWords--;
     param++;
+  }
+  // If there's a waveform, full it with rEvent[0]..
+  if (!m_pWf) {
+    OnEventSourceOpen("test");
+  }
+  if (m_pWf) {
+    std::vector<uint16_t> trace;
+    for (int i =0; i < m_pWf->size(); i++) {
+      trace.push_back(i+event.raw[0]);
+    }
+    m_pWf->update(trace.data());
+    // Make some fits
+    // lower is flat, the first waveform point,
+    // uppoer is flat, the last waveform point.
+    std::vector<double> lower;
+    std::vector<double> upper;
+    for (int i =0; i < m_pWf->size(); i++) {
+      lower.push_back(trace[0]);
+      upper.push_back(trace[trace.size()-1]);
+    }
+    m_pWf->fillFit(size_t(0), lower.data());
+    m_pWf->fillFit(size_t(1), upper.data());
+
   }
   return kfTRUE;		// kfFALSE would abort pipeline.
 }
@@ -256,7 +289,12 @@ elements 1 and 2 and putting the result into element 0.
 void
 CMySpecTclApp::CreateAnalysisPipeline(CAnalyzer& rAnalyzer)
 {
-
+  CWaveform wf("test", 500);
+  wf.setMetadata("frequency", "500MHz");
+  wf.setMetadata("meaning", "Central Contact");
+  wf.addFit("lower");
+  wf.addFit("upper");
+  SpecTcl::getInstance()->addWaveform(wf);
 #ifdef WITHF77UNPACKER
   RegisterEventProcessor(legacyunpacker);
 #endif

--- a/main/Utility/TclDict.cpp
+++ b/main/Utility/TclDict.cpp
@@ -21,14 +21,19 @@
 
 #include "TclDict.h"
 #include "TCLInterpreter.h"
-#include "TCLObject.h"
+
+#include <stdexcept>
+#include <sstream>
 
 /**
- * This file provides overloads for DictPut.  Regardless of parameter types:
+ * This section of the file provides overloads for DictPut.  Regardless of parameter types:
  * - pInterp - is the interpreter on which the dictionary object is defined.
  * - dict    - is the dictionary affected.
  * - key     - Is a dictionary key.
  * - value   - Is a value to be added to the dict.
+ * 
+ * Return value is Tcl_Ok on success and Tcl_Error on faliure.  Failure happens only if the
+ * input dict is not a valid dictionary (e.g. {a b c} is not a valid dict.)
  */
 
 int
@@ -66,3 +71,66 @@ Tcl::DictPut(
     Tcl_Obj* pValue = Tcl_NewStringObj(value, -1);
     return DictPut(interp, dict, key, pValue);
 }
+/**
+ * This section of the file cotains overloads for dictGet
+ * - rInterp is a reference to an interpreter object.
+ * - dict is a CTCLObject referencde containing a dictionary.,
+ * - key is the key whose value we will fetch.
+ * 
+ * The functions return the value in various forms.  Note that
+ * input CTCLObject parameters will wind up bound to the rInterp.
+ * Output CTCLObjects will also be bound to the rInterp.
+ * A few exceptions are possible:
+ * 
+ * -  std::out_of_range - if the dictionary does not have the specified key.
+ * -  std::invalid_argument -if the dictionary parameter is not a valid dict (e.g. 
+ *    Tcl_DictObjGet) return Tcl_Error.
+ */
+
+ // This is the one on which all the others can be based:
+ // note CTCLObject copy construct ....
+ CTCLObject
+ Tcl::DictGet(
+        CTCLInterpreter& rInterp, CTCLObject& dict, CTCLObject& key
+    ) {
+        
+        Tcl_Obj* oResult;
+        
+        int status = Tcl_DictObjGet(
+            rInterp.getInterpreter(), dict.getObject(), key.getObject(), &oResult
+        );
+        if (status != TCL_OK) {
+            throw std::invalid_argument("Tcl::dictGet - invalid dictionary passed in");
+        }
+        if (!oResult) {
+            std::stringstream smsg;
+            smsg << "Dictionary does not have key" << std::string(key);
+            std::string msg(smsg.str());
+            throw std::out_of_range(msg);
+        }
+
+        // All ok, so wrap the oResult:
+
+        CTCLObject result(oResult);
+        result.Bind(rInterp);
+        return result;
+    }
+    // For this one, we just need to wrap the key in  a CTCLObject then 
+    // call the preveous overload:
+
+    CTCLObject
+    Tcl::DictGet(CTCLInterpreter& rInterp, CTCLObject& dict, const char* key) {
+        CTCLObject okey;
+        okey.Bind(rInterp);
+        okey = std::string(key);
+
+        return Tcl::DictGet(rInterp, dict, okey);
+    }
+    // For this one we just need to unwrap the object returned by the previous one:
+
+    std::string 
+    Tcl::DictGetAsStr(CTCLInterpreter& rInterp, CTCLObject& dict, const char* key) {
+        CTCLObject objResult = Tcl::DictGet(rInterp, dict, key);
+        return std::string(objResult);
+    }
+

--- a/main/Utility/TclDict.h
+++ b/main/Utility/TclDict.h
@@ -22,7 +22,8 @@
 #define TCLDICT_H
 
 #include <tcl.h>
-class CTCLObject;
+#include <string>
+#include <TCLObject.h>
 class CTCLInterpreter;
 
 namespace Tcl {
@@ -41,6 +42,16 @@ namespace Tcl {
         CTCLInterpreter& pInterp, CTCLObject& dict, const char* key,
         const char* value
     );
+    std::string DictGetAsStr(
+        CTCLInterpreter& rInterp, CTCLObject& dict, const char* key  // else next one is ambiguous overload.
+    );
+    CTCLObject DictGet(
+        CTCLInterpreter& rInterp, CTCLObject& dict, const char* key
+    );
+    CTCLObject DictGet(
+        CTCLInterpreter& rInterp, CTCLObject& dict, CTCLObject& key
+    );
+
 }
 
 #endif

--- a/main/const/Makefile.am
+++ b/main/const/Makefile.am
@@ -19,7 +19,7 @@ AM_CPPFLAGS		= -I. $(SPECTCLCCSW) \
 
 libconstparam_la_LDFLAGS=@ROOT_LDFLAGS@ @LIBTCLPLUS_LDFLAGS@ @TCL_LIBS@
 
-install-exec-local: const.pdf
+install-exec-local: @builddir@/const.pdf
 	$(mkinstalldirs) @prefix@/share/const-plugin
 	$(mkinstalldirs) $(prefix)/TclLibs $(prefix)/TclLibs/constparam
 	for f in .libs/lib*; do $(INSTALL_PROGRAM) $$f $(prefix)/TclLibs/constparam; done
@@ -28,8 +28,10 @@ install-exec-local: const.pdf
 
 EXTRA_DIST	= const.xml
 
-const.pdf:	const.xml
+@builddir@/const.pdf:	const.xml
 	@PDFDOCBOOK@ @srcdir@/const.xml
 
+distclean-hook:
+	rm -f const.pdf
 
 docs:   const.pdf

--- a/main/docs/docbook/CommandReference.xml
+++ b/main/docs/docbook/CommandReference.xml
@@ -7279,6 +7279,12 @@ waveform metadata get wvname ?name?
         <cmdsynopsis><command>
 waveform resize name samples
         </command></cmdsynopsis>
+        <cmdsynopsis><command>
+waveform fits wfname ?pattern?
+        </command></cmdsynopsis>
+        <cmdsynopsis><command>
+waveform getall name1...
+        </command></cmdsynopsis>
     </refsynopsisdiv>
     <refsect1>
         <title>DESCRIPTION</title>
@@ -7395,14 +7401,53 @@ waveform resize name samples
                 a dict whose keys are metadata values and whose values are the values of each key.
             </para>
         </refsect2>
-    </refsect1>
-    <refsect1>
-        <title>Resizing waveforms</title>
-        <para>
-            The <command>resize</command> subcommand resizes the waveform storage associated with a 
-            waveform.  The first additional parameter  is the name of the waveform to be affected.  The second,
-            the new sample count.
-        </para>
+
+        
+        <refsect2>
+            <title>Resizing waveforms</title>
+            <para>
+                The <command>resize</command> subcommand resizes the waveform storage associated with a 
+                waveform.  The first additional parameter  is the name of the waveform to be affected.  The second,
+                the new sample count.
+            </para>
+        </refsect2>
+        <refsect2>
+            <title>Listing fits associated with a waveform.</title>
+            <para>
+                Waveforms can have fits associated with them.  These fits must be programmatically
+                created.  See the programming guide and reference for information about how to 
+                associated fits with waveform objects.
+            </para>
+            <para>
+                The <command>fits</command> subcommand takes the name of a waveform and an optional
+                glob pattern which defaults to <literal>*</literal>.  It returns a list of all
+                fits whose names match the glob pattern parameter.  Each element of the list is a 
+                dict with the keys <literal>name</literal> whose value is the fit name and
+                <literal>points</literal> whose value is a list of real numbers that make up the
+                fit points for the most recently processed event.
+            </para>
+        </refsect2>
+        <refsect2>
+            <title>Getting wavevorms and their fits</title>
+            <para>
+                The <command>getall</command> subcommand takes additional parameters that are
+                waveform names. The result is a list of dicts, one for each waveform specified.
+                The dict keys are <literal>name</literal> whose datum is the name of the waveform
+                object being described, <literal>waveform</literal> the waveform, see below.
+                <literal>fits</literal> a list of fits (pissibly empty) see below.
+            </para>
+            <para>
+                The fit is returned as a three element list containing, in order, the name of the fit,
+                the waveform samples as a  sub-list, and the rank of the computation that's returned this
+                result.  In serial SpecTcl the rank is always zero.  In MPISpecTcl, the rank identifies the
+                worker process and will be a value that is at least 2.
+            </para>
+            <para>
+                The waveformw are returned as a sublist where each sublist element is a dict with the keys:
+                <literal>name</literal> containing the name of the fit and 
+                <literal>pionts</literal> containig a list of real values that are the fit points.
+            </para>
+        </refsect2>
     </refsect1>
 </refentry>
 

--- a/main/docs/docbook/ProgrammingGuide.xml
+++ b/main/docs/docbook/ProgrammingGuide.xml
@@ -10845,6 +10845,10 @@ pman use raw                               <co id='dynpipe.pman.use'/>
         and filled in by event processors.
     </para>
     <para>
+        Waveforms can also have any number of named fitlines associated with them. Those fits
+        are superimposed on the display of the waveform in the tree GUI.
+    </para>
+    <para>
         This chapter summarizes the process of creating a waveform (at the command level), 
         locating the <classname>CWaveform</classname> object you create, and updating the
         waveform contents from within your event processor.
@@ -10866,6 +10870,7 @@ pman use raw                               <co id='dynpipe.pman.use'/>
             Waveform objects have a name, a size, along with storage for a waveform as well as arbitrary metadata
             you can use as you choose (e.g. to store the digitizer frequency or resolution). 
         </para>
+        
         <para>
             The example below shows how to create and register a waveform object within an event processor.
             Note that registering a waveform with the dictionary copies the waveform object making it necessary
@@ -11012,6 +11017,103 @@ waveform metadata set test Frequency  100MHz bits 14 <co id='wf2.metaset' />
             The code to locate and fill the event processor in the event processor is the same as that
             shown in <link linkend='wf1.example' endterm='wf1.example.title' />.
         </para>
+    </section>
+    <section>
+        <title>Associating fit lines with a waveform.</title>
+        <para>
+            The  <methodname>addFit</methodname> of <classname>CWaveform</classname> provides
+            the ability to associated fit data with each waveform. As long as fit names are unique,
+            any number of fits can be associated.   The TreeGUI automatically plots fit data supermiposed
+            on the waveform. The <methodname>fillFit</methodname> method fills the fit with data.
+        </para>
+        <para>
+            Fits have a fit index associated with the fit line and it's recommended that you use
+            the index to refer to the fit during event processing, as this can be quite a bit faster
+            than forcing the fit object to look up the fit by name.
+        </para>
+        <para>
+            The example below shows how to add a fit to a waveform in the event process and to 
+            fill in the fit.  It is a modification of
+            <link linkend='wf1.example' endterm='wf1.example.title' />
+        </para>
+        <example id='wffit.example'>
+            <title id='wffit.example.title'>Using fits with CWaveform</title>
+            <programlisting>
+class MyEp : public CEventProcessor {
+private:
+    CWaveform* m_pWf;           
+    size_t     m_fitIndex;       <co id='wffit.index' />
+public:
+    Bool_t OnAttach(CAnalyzer&amp; ra);  
+    ...
+    Bool_t operator()(const Address_t pEvent,
+                            CEvent&amp; rEvent,
+                            CAnalyzer&amp; rAnalyzer,
+                            CBufferDecoder&amp; rDecoder);
+    std::vector&lt;double&gt; vitWaveform(const uint16_t* waveform);
+};
+...
+Bool_t
+MyEp::OnAttach(CAnalyzer&amp; ra) {
+    CWaveform awaveform("test", 100);
+    awaveform.setMetadata("Frequency", "250MHz"); 
+    awaveform.setMetadata("bits", "14");
+    m_fitIndex = awaveform.addFit("somefit");  <co id='wffit.add' />
+
+    SpecTcl* api = SpecTcl::getInstance();
+    api-&gt;addWaveform(awaveform);                   
+    m_pWf = api-&gt;findWaveform("test");             
+}
+
+
+Bool_t
+    MyEp::operator()(const Address_t pEvent,
+                                CEvent&amp; rEvent,
+                                CAnalyzer&amp; rAnalyzer,
+                                CBufferDecoder&amp; rDecoder) {
+    uint16_t waveformdata[100];                 
+    ....
+
+    m_pWf-&gt;update(waveformdata);
+    std::vector&lt;double&gt; fit = fitWaveform(waveformdata);   <co id='wffit.fit' />
+    m_pWf->fillFit(m_fitIndex, fit.data());             <co id='wffit.fill' />
+}
+            </programlisting>
+        </example>
+        <para>
+            Again refer to the numbers in the example when reading these annotations:
+        </para>
+        <calloutlist>
+            <callout arearefs='wffit.index'>
+                <para>
+                    Since it is more computationally efficient to refer to fits by their index,
+                    this creates member data to hold the index of the fit we are going to create.
+                </para>
+            </callout> 
+            <callout arearefs='wffit.add'>
+                <para>
+                    This line adds the fit to the waveform we are creating. The actual
+                    fit data are all initialized to 0.0.  The <methodname>addFit</methodname>
+                    returns the index of the added fit which we save in our
+                    <varname>m_fitIndex</varname> member data.
+                </para>
+            </callout>
+            <callout arearefs='wffit.fit'>
+            <para>
+                We've hidden the actual fitting so that filling the fit data does not actually
+                clutter the example.
+            </para>
+            </callout>
+            <callout arearefs='wffit.fill'>
+                <para>
+                    The <methodname>fillFit</methodname> puts our fit data into the fitline.
+                    <methodname>std::vector::data</methodname> returns a pointer to the fit storage
+                    as expected by <methodname>fillFit</methodname>.  This storage must
+                    be at least <literal>m_PWf.size()</literal> doubles big to provide a
+                    fit point for each waveform sample.
+                </para>
+            </callout>
+        </calloutlist>
     </section>
 </chapter>
 </book>

--- a/main/docs/docbook/pgmref.xml
+++ b/main/docs/docbook/pgmref.xml
@@ -34710,6 +34710,7 @@ class CWaveform : public CNamedItem {
 public:
     typedef std::map&lt;std::string, std::string&gt; Metadata_t;
     typedef std::vector&lt;uint16_t&gt;  WaveForm_t;
+    typedef std::vector&lt;double&gt;    Fit_t; 
 public:
 
     CWaveform(const char* name, size_t nSamples);
@@ -34719,10 +34720,18 @@ public:
     std::string getMetadata(const char* name) const;
     const Metadata_t&amp; getMetadata() const;
 
-    void update(const uint16_t* data);    // Update the waveform.
+    void update(const uint16_t* data);    
     const WaveForm_t&amp; trace() const;
-    void resize(unsigned nSample);        // Change # of samples.
+    void resize(unsigned nSample);        
     size_t size() const;
+
+    size_t addFit(const char* fitName);
+    size_t findFit(const char* fitName) const;
+    const Fit_t&amp; getFit(size_t fitno) const;
+    const Fit_t&amp; getFit(const char* fitName)const ;
+    void fillFit(size_t fitno, const double* pData);
+    size_t fillFit(const char* fitName, const double* pData); 
+    std::vector&lt;std::pair&lt;std::string, size_t&gt; &gt; listFits() const;
 
 
 private:
@@ -34871,6 +34880,97 @@ private:
                     Returns the number of samples the waveform has.
                 </para></listitem>
             </varlistentry>
+            <varlistentry>
+                    <term><methodsynopsis>
+                        <type>size_t</type> <methodname>addFit</methodname>
+                        <methodparam>
+                            <type>const char*</type> <parameter>fitname</parameter>
+                        </methodparam>
+                        </methodsynopsis>
+                    </term>
+                    <listitem>
+                        <para>
+                            Adds a fit object to the waveform.   The <parameter>fitname</parameter>
+                            and an integer index identify the fit. The <parameter>fitname</parameter>
+                            must be unique or else a <classname>CDuplicateSingleton</classname> is
+                            exception is thrown.  The return value is the integer index assigned to the
+                            fit.
+                        </para>
+                        <para>
+                            Identifying a fit by index is done is constant time, while identifying it
+                            by name is O(log n) time where n is the number of fits defined on the
+                            waveform.  It is recommended, therefore, that you use fit indices in event
+                            processing.
+                        </para>
+                    </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><methodsynopsis>
+                    <type>size_t</type> <methodname>findFit</methodname>
+                    <methodparam> <type>const char*</type> <parameter>fitName</parameter>
+                    </methodparam><modifier>const</modifier>
+                </methodsynopsis></term>
+                <listitem><para>
+                    Given a valid <parameter>fitName</parameter>, returns the index of the fit.
+                    If the fit does not exist, a <classname>CNoSuchObjectException</classname> is thrown.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                    <term><methodsynopsis>
+                        <type>const Fit_t&amp;</type> <methodname>getFit</methodname>
+                        <methodparam><type>size_t</type> <parameter>fitNo</parameter></methodparam>
+                        <modifier>const</modifier>
+                    </methodsynopsis>
+                    </term>
+                    <listitem>
+                        <para>
+                            Returns the fit indexed by <parameter>fitNo</parameter>  this index
+                            should have either been returned from <methodname>addFit</methodname>
+                            or <methodname>findFit</methodname>  See
+                            <literal>DATA TYPES</literal> for what a <type>Fit_t</type> is.
+                            Note that what is retunred is a const reference so there's no data movement
+                            but you may not modify the fit constants.  See the <methodname>fillFIt</methodname>
+                            methods below.
+                        </para>
+                    </listitem>
+            </varlistentry>
+            <varlistentry>
+                    <term><methodsynopsis>
+                        <type>const Fit_t&amp;</type> <methodname>getFit</methodname>
+                        <methodparam><type>const char*</type> <parameter>fitName</parameter></methodparam>
+                        <modifier>const</modifier>
+                    </methodsynopsis></term>
+                    <listitem>
+                        <para>
+                            Returns a const reference to a fit given its name; <parameter>fitName</parameter>
+                        </para>
+                    </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><methodsynopsis>
+                    <type>void</type> <methodname>fillFit</methodname>
+                    <methodparam><type>size_t</type> <parameter>fitNo</parameter></methodparam>
+                    <methodparam><type>const double*</type> <parameter>pData</parameter></methodparam>
+                </methodsynopsis></term>
+                <listitem><para>
+                    Fills the fit selectd by the fit index <parameter>fitNo</parameter> with the data
+                    from <parameter>pData</parameter>  this must point to at least the number of doubles
+                    that are in the size of the waveform, so that the fit will have one point for each point
+                    in the waveform.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><methodsynopsis>
+                    <type>std::vector&lt;std::pair&lt;std::string, size_t&gt;&gt;</type>
+                    <methodname>listFits</methodname><void /><modifier>const</modifier>
+                </methodsynopsis></term>
+                <listitem><para>
+                    Returns a vector that contains the correspondence between all fit names and their
+                    indicies.   You should not rely on this being in any spefici order.  Each pair of the
+                    vector, contains the name of a fit and its index (the value that would be returned from 
+                    <methodname>findFit</methodname> for that name).)
+                </para></listitem>
+            </varlistentry>
         </variablelist>
     </refsect1>
     <refsect1>
@@ -34894,6 +34994,13 @@ private:
                     Waveforms are held in vectors.  <methodname>update</methodname> is used to
                     load a new waveform and <methodname>trace</methodname> to get a const reference
                     to the waveform.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><type>Fit_t</type></term>
+                <listitem><para>
+                    This type is just a vector of double.   The elements of the vector are the
+                    fit values for the corresponding index of the <type>Waveform_t</type>.
                 </para></listitem>
             </varlistentry>
         </variablelist>

--- a/main/firstof/Makefile.am
+++ b/main/firstof/Makefile.am
@@ -14,7 +14,7 @@ libfirstof_la_LDFLAGS = @ROOT_LDFLAGS@ @TCL_LIBS@ @LIBTCLPLUS_LDFLAGS@
 libfirstof_la_CPPFLAGS=@ROOT_CFLAGS@ @TCL_CPPFLAGS@ @LIBTCLPLUS_CFLAGS@ \
 	-I@top_srcdir@/Core -I@top_srcdir@/Utility -I@top_srcdir@/factories
 
-install-exec-local: firstof.pdf
+install-exec-local: @builddir@/firstof.pdf
 	$(mkinstalldirs) $(prefix)/TclLibs
 	$(mkinstalldirs) @prefix@/share/firstof-plugin
 	for f in .libs/lib*; do $(INSTALL_PROGRAM) $$f $(prefix)/TclLibs; done
@@ -24,8 +24,10 @@ install-exec-local: firstof.pdf
 
 EXTRA_DIST	=	firstof.xml
 
+distclean-hook:
+	rm -f firstof.pdf
 
-firstof.pdf: firstof.xml
+@builddir@/firstof.pdf: firstof.xml
 	@PDFDOCBOOK@ @srcdir@/firstof.xml
 
 docs: firstof.pdf

--- a/main/map/Makefile.am
+++ b/main/map/Makefile.am
@@ -19,7 +19,7 @@ libMapValues_la_SOURCES =	CMapValueCommand.cpp	\
 noinst_HEADERS	=		CMapValueCommand.h	\
 				CMapValueProcessor.h
 
-install-exec-local: mapvalues.pdf
+install-exec-local: @builddir@/mapvalues.pdf
 	$(mkinstalldirs) $(prefix)/TclLibs
 	$(mkinstalldirs) $(prefix)/TclLibs/mapvalues
 	$(mkinstalldirs) @datarootdir@/mapvalues-plugin
@@ -30,8 +30,10 @@ install-exec-local: mapvalues.pdf
 
 EXTRA_DIST=mapvalues.xml
 
+distclean-hook:
+	rm -r mapvalues.pdf
 
-mapvalues.pdf: mapvalues.xml
+@builddir@/mapvalues.pdf: mapvalues.xml
 	$(PDFDOCBOOK) @srcdir@/mapvalues.xml
 
 

--- a/main/radwareio/Makefile.am
+++ b/main/radwareio/Makefile.am
@@ -26,14 +26,16 @@ libradwareio_la_LDFLAGS=@ROOT_LDFLAGS@ @LIBTCLPLUS_LDFLAGS@ @TCL_LIBS@
 
 EXTRA_DIST = permission.txt radwareio.xml
 
-install-exec-local: radwareio.pdf
+install-exec-local: @builddir@/radwareio.pdf
 	$(mkinstalldirs) $(prefix)/TclLibs
 	$(mkinstalldirs) @datarootdir@/radwareio-plugin
 	for f in .libs/lib*; do $(INSTALL_PROGRAM) $$f $(prefix)/TclLibs; done
 	$(INSTALL_DATA) @builddir@/radwareio.pdf @datarootdir@/radwareio-plugin
 
+distclean-hook:
+	rm -rf radwareio.pdf
 
-radwareio.pdf: radwareio.xml
+@builddir@/radwareio.pdf: radwareio.xml
 	@PDFDOCBOOK@ @srcdir@/radwareio.xml
 
 docs: radwareio.pdf

--- a/main/rest/custom/waveform.tcl
+++ b/main/rest/custom/waveform.tcl
@@ -54,6 +54,12 @@ namespace eval waveform {
             rank  [lindex $trace 2]   \
         ]
     }
+    proc _formatFit fit {
+        return [json::write object                                \
+            name [json::write string [dict get $fit name]]        \
+            points [json::write array {*}[dict get $fit points]]  \
+        ]
+    }
 }
 ##
 # SpecTcl_waveform/create
@@ -211,4 +217,71 @@ proc SpecTcl_waveform/resize {name samples} {
         ]
     } 
     SpecTcl::_returnObject OK
+}
+##
+# SpecTcl_waveform/fits
+#
+#   For a waveform, returns the fits associated with it
+#
+# Query parameters:
+#   @param name - name of the waveform.
+#   @param pattern - pattern that filters the fit names.
+#
+# Result:
+#   Detail is a JsON array of fit descriptions.  The attributes of each description are
+# - name  - the name of the fit.
+# - pointes - Array of real valued points.
+#
+proc SpecTcl_waveform/fits {name {pattern *}} {
+    set ::SpecTcl_waveform/fits application/json;   # Return json.
+
+    set status [catch {
+        waveform fits $name $pattern
+    } raw]
+    if {$status} {
+        return [SpecTcl::_returnObject "'waveform fit' failed" \
+            [json::write string $raw]]
+    }
+    set descList [list]
+    foreach fit $raw {
+        lappend descList [waveform::_formatFit $fit]
+    }
+    SpecTcl::_returnObject OK [json::write array {*}$descList]
+}
+##
+# SpecTcl_waveform/getall
+#   Gets all the information about a single waveform
+#
+# Query Parameters:
+#   @param name - the name of a waveform object.
+#
+# Result:
+#  Detail is a dict containing
+#    name - name of the waveform.
+#    waveform - an object as you might get from the get method.
+#    fits     - an array of fit objects such as you might get from the fits method.
+#
+proc SpecTcl_waveform/getall {name} {
+    set ::SpecTcl_waveform/getall application/json
+
+    set status [catch \
+        {waveform getall $name} raw
+    ] 
+    if {$status} {
+        return [SpecTcl::_returnObject "'waveform getall' failed" \
+        [json::write string $raw]]
+    }
+
+    set desc [lindex $raw 0];    # it's a list, this gets the description.
+    set name [dict get $desc name]
+    set wf   [waveform::_traceToJson [dict get $desc waveform]]
+    set fits [list]
+    foreach fit [dict get $desc fits] {
+        lappend fits [waveform::_formatFit $fit]
+    }
+    SpecTcl::_returnObject OK [json::write object \
+        name [json::write string $name]           \
+        waveform $wf                              \
+        fits [json::write array {*}$fits]         \
+    ]
 }

--- a/main/rest/installer
+++ b/main/rest/installer
@@ -13,5 +13,5 @@ tar czf - bin lib custom  htdocs_2 startServer.tcl pkgIndex.tcl | \
 
 mkdir -p $docdir
 
-docbook2pdf -o $docdir  restdocs.xml 
+docbook2html -o $docdir  restdocs.xml 
 

--- a/main/rest/restdocs.xml
+++ b/main/rest/restdocs.xml
@@ -4181,6 +4181,119 @@ http://host:port/spectcl/waveform/resize?name=<replaceable>wfname</replaceable>&
                     The waveform is initialized to zero.
                 </para>
             </section>
+            <section>
+                <title>Listing fits associated with waveforms.</title>
+                <informalexample>
+                    <cmdsynopsis><command>
+    http://host:port/spectcl/waveform/fits?name=<replaceable>wfname</replaceable><optional>&amp;pattern=<replaceable>fit-pat</replaceable></optional>
+                    </command></cmdsynopsis>
+                </informalexample>
+                <para>
+                    Lists the fits associated with waveform in the <literal>name></literal> query
+                    parameter whose names match the glob <parameter>fit-pat</parameter> in the 
+                    <literal>pattern</literal> optional query parameter.  If the <literal>pattern</literal>
+                    query parameter is not provided it defaults to <literal>*</literal> which matches all
+                    fits.
+                </para>
+                <para>
+                    On success, detail is an array of objects with the attributes:
+                </para>
+                <variablelist>
+                    <varlistentry>
+                            <term><literal>name</literal></term>
+                            <listitem>
+                                <para>
+                                    Contaqins the name of the fit.
+                                </para>
+                            </listitem>
+                    </varlistentry>
+                    <varlistentry>
+                            <term><literal>points</literal></term>
+                            <listitem>
+                                <para>
+                                    Contains an array of real number that are the fit points.
+                                    There will be one fit point corresponding to each waveform 
+                                    sample.
+                                </para>
+                            </listitem>
+                    </varlistentry>
+                </variablelist>
+            </section>
+            <section>
+                <title>Getting synchronized waveforms and fits.</title>
+                <informalexample>
+                    <cmdsynopsis><command>
+    http://host:port/spectcl/waveform/getall?name=<replaceable>wfname</replaceable>
+                    </command></cmdsynopsis>
+                </informalexample>
+                <para>
+                    fetches waveform and fit information for a waveform named by the
+                    <literal>name</literal> parameter.  The waveform and fit are gotten in a way
+                    that you can be guaranteed that the waveform samples and fit points are from
+                    the same event.
+                </para>
+                <para>
+                    Note that at present, this can only get the information from a single
+                    waveform object. The detail, on success is a an object with the following
+                    attributes:
+                </para>
+                <variablelist>
+                    <varlistentry>
+                            <term><literal>name</literal></term>
+                            <listitem>
+                                <para>
+                                    Name of the wvaeform.  Note that the underlying command
+                                    allows more than one waveform to be queried, in the future
+                                    this may be supported.
+                                </para>
+                            </listitem>
+                    </varlistentry>
+                    <varlistentry>
+                            <term><literal>waveform</literal></term>
+                            <listitem>
+                                <para>
+                                    An array of integers samples of the waveform.
+                                </para>
+                            </listitem>
+                    </varlistentry>
+                    <varlistentry>
+                            <term><literal>fits</literal></term>
+                            <listitem>
+                                <para>
+                                    An array of JsON ojects.  Each element of the array 
+                                    contains a description of one fit and has the
+                                    following attributes:
+                                </para>
+                                <variablelist>
+                                    <varlistentry>
+                                            <term><literal>name</literal></term>
+                                            <listitem>
+                                                <para>
+                                                    The name of the <emphasis>fit</emphasis>
+                                                </para>
+                                            </listitem>
+                                    </varlistentry>
+                                    <varlistentry>
+                                            <term><literal>points</literal></term>
+                                            <listitem>
+                                                <para>
+                                                    Array of real valued fit points. There will be
+                                                    one fit point corresponding to each fo the waveform
+                                                    samples.
+                                                </para>
+                                            </listitem>
+                                    </varlistentry>
+                                </variablelist>
+                            </listitem>
+                    </varlistentry>
+                </variablelist>
+                <para>
+                    Since SpecTcl is running asynchronously to the client if you do a <literal>get</literal>
+                    method followed by a <literal>fits</literal> method call you are likely to get waveform and
+                    fit from different events.   This <literal>getall</literal> method solves that problem.
+                </para>
+            </section>
+
         </section>
     </chapter>
 </book>

--- a/main/rest/restdocs.xml
+++ b/main/rest/restdocs.xml
@@ -4252,8 +4252,37 @@ http://host:port/spectcl/waveform/resize?name=<replaceable>wfname</replaceable>&
                             <term><literal>waveform</literal></term>
                             <listitem>
                                 <para>
-                                    An array of integers samples of the waveform.
+                                    A JsON object with the following attributes:
                                 </para>
+                                <variablelist>
+                                    <varlistentry>
+                                            <term><literal>name</literal></term>
+                                            <listitem>
+                                                <para>
+                                                    The name of the waveform.
+                                                </para>
+                                            </listitem>
+                                    </varlistentry>
+                                    <varlistentry>
+                                            <term><literal>samples</literal></term>
+                                            <listitem>
+                                                <para>
+                                                    Array of integer valued waveform samples
+                                                </para>
+                                            </listitem>
+                                    </varlistentry>
+                                    <varlistentry>
+                                            <term><literal>rank</literal></term>
+                                            <listitem>
+                                                <para>
+                                                    The rank of the process from which this was returned.
+                                                    This will be zero for serial SpecTcl and some integer
+                                                    2 or larger for MPISpecTcl identifying which worker 
+                                                    contributed this result.
+                                                </para>
+                                            </listitem>
+                                    </varlistentry>
+                                </variablelist>
                             </listitem>
                     </varlistentry>
                     <varlistentry>

--- a/main/restclient/SpecTclRestCommand.tcl
+++ b/main/restclient/SpecTclRestCommand.tcl
@@ -2086,7 +2086,7 @@ proc mirror {list {pattern *}} {
 #  It's a namespaxce ensemble.
 
 namespace eval waveform {
-    namespace export create metadata get resize   _defaultCreate
+    namespace export create metadata get resize   _defaultCreate fits getall
     namespace ensemble create
 
     proc _metadataToDict {metaList} {
@@ -2197,6 +2197,16 @@ namespace eval waveform {
     # @return none.
     proc resize {name samples} {
         return [$::SpecTclRestCommand::client waveformResize $name $samples]    
+    }
+
+    ##
+    # fits
+    #   List the fits that are associated with a waveform.
+    # 
+    # @param name - waveform name.
+    # @param pattern - optional pattern that restricts the set of fits returned.
+    proc fits {name {pattern *}} {
+        return [$::SpecTclRestCommand::client waveformListFits $name $pattern]
     }
         
 }

--- a/main/restclient/SpecTclRestCommand.tcl
+++ b/main/restclient/SpecTclRestCommand.tcl
@@ -2208,6 +2208,15 @@ namespace eval waveform {
     proc fits {name {pattern *}} {
         return [$::SpecTclRestCommand::client waveformListFits $name $pattern]
     }
+    ##
+    # getall
+    #   Get the waveform and associated fits data for an event.
+    #
+    # @param name - name of the waveform.
+    #
+    proc getall {name} {
+        return [$::SpecTclRestCommand::client waveformGetAll $name]
+    }
         
 }
 ## default unkown handler for waveform namepace assumes a create:

--- a/main/restclient/restclient.tcl
+++ b/main/restclient/restclient.tcl
@@ -1817,6 +1817,7 @@ snit::type SpecTclRestClient {
     #    Gets waveform samples and points for the same event in a waveform.
     #  @param name - waveform name.  There can only be one at present.
     #  @return dict containing the keys:
+    #      name     - Name of the waveform.
     #      waveform - object describing the waveform.  A dict containing:
     #          name - name of the waveform.
     #          samples - array of integer waveform samples

--- a/main/restclient/restclient.tcl
+++ b/main/restclient/restclient.tcl
@@ -1812,4 +1812,23 @@ snit::type SpecTclRestClient {
         set result [$self _request [$self _makeUrl waveform/fits $qdict]]
         return [dict get $result detail]
     }
+    ##
+    #  waveformGetAll
+    #    Gets waveform samples and points for the same event in a waveform.
+    #  @param name - waveform name.  There can only be one at present.
+    #  @return dict containing the keys:
+    #      waveform - object describing the waveform.  A dict containing:
+    #          name - name of the waveform.
+    #          samples - array of integer waveform samples
+    #          rank    - in MPISpecTcl the rank of the process from which this came.
+    #       fits  - A list of dicts, each dict containing information about a fit:
+    #          name - the name of the fit.
+    #          points - list of real valued fit points.
+    #         
+    #
+    method waveformGetAll {name} {
+        set qdict [dict create name $name]
+        set result [$self _request [$self _makeUrl waveform/getall $qdict]]
+        return [dict get $result detail]
+    }
 }

--- a/main/restclient/restclient.tcl
+++ b/main/restclient/restclient.tcl
@@ -158,6 +158,15 @@ package require json
 #   evbCreate
 #   evbAdd
 #   evbList
+#   
+#   waveformCreate
+#   waveformList
+#   waveformGet
+#   waveformGetMetadata
+#   waveformSetMetadata
+#   waveformResize
+#   waveformListFits
+#   waveformGetAll
 #
 #   command
 #
@@ -1787,5 +1796,20 @@ snit::type SpecTclRestClient {
     method waveformResize {name samples} {
         set qdict [dict create name $name samples $samples]
         $self _request [$self _makeUrl waveform/resize $qdict]
+    }
+
+    ##
+    #  waveformListFits
+    #    Lists the characteristics of the fits with names that match the pattern
+    # @param name - waveform name.
+    # @param pattern - glob pattern that must match to be listed.  Defaults to "*"
+    # @return List of dicts where each dict has the keys:
+    #    name - fit name.
+    #    points - List of real valued fit points.
+    #
+    method waveformListFits {name {pattern *}} {
+        set qdict [dict create name $name pattern $pattern]
+        set result [$self _request [$self _makeUrl waveform/fits $qdict]]
+        return [dict get $result detail]
     }
 }

--- a/main/restclient/restclientdocs.xml
+++ b/main/restclient/restclientdocs.xml
@@ -404,6 +404,8 @@ c destroy                                     <co id='ex.client.destroy' />
     $client waveformGetMetadata name ?key?
     $client waveformSetMetadata name name1 value1 ?name2 value2 ...?
     $client waveformResize name newsamples
+    $client waveformListFits name ?fit-pat?
+    $client waveformGetAll name
     
                     </programlisting>
                 </refsynopsisdiv>
@@ -3847,6 +3849,64 @@ c destroy                                     <co id='ex.client.destroy' />
                                         to <parameter>new-size</parameter>.  The resulting waveform is cleared to all zeroes.
                                     </para>
                                 </listitem>
+                            </varlistentry>
+                            <varlistentry>
+                                    <term><literal>waveformListFits</literal> <replaceable>name ?fit-pat?</replaceable></term>
+                                    <listitem>
+                                        <para>
+                                            Returns a list of the fits that have been associated with the waveform
+                                            <parameter>name</parameter>.  If the optional <parameter>fit-pat</parameter>
+                                            parameter is supplied,  only fits with names that match the glob pattern
+                                            <parameter>fit-pat</parameter> will be listed.  This defaults to
+                                            <literal>*</literal> if not supplied, which matches all fit names.
+                                        </para>
+                                        <para>
+                                            The returned value is a list of dicts that contain the keys:
+                                            <literal>name</literal> and <literal>points</literal>.
+                                            The value of the <literal>name</literal> key is the name of the
+                                            fit.  The value of the <literal>points</literal> is a list
+                                            of real valued fit points for the most recently processed event.
+                                        </para>
+                                        <para>
+                                            Be sure to see <literal>waveformGetAll</literal> below as this
+                                            is the preferred way to get waveform samples and fit points.
+                                        </para>
+                                    </listitem>
+                            </varlistentry>
+                            <varlistentry>
+                                    <term><literal>waveformGetAll</literal> <replaceable>name</replaceable></term>
+                                    <listitem>
+                                        <para>
+                                            Gets waveform samples and fit points for the most recent event.
+                                            Note that since SpecTcl runs asynchonously to its ReST clients, 
+                                            doing a waveformGet followed by a waveformListFits, in general, 
+                                            won't get samples and points from the same event.  This
+                                            method guarantees that samples and points are from the same event.
+                                        </para>
+                                        <para>
+                                            The <parameter>name</parameter> specifies the name of the
+                                            waveform for which data will be returned.  The returned value
+                                            is a dict that has the keys <literal>waveform</literal>
+                                            and <literal>fits</literal>
+                                        </para>
+                                        <para>
+                                            The contents of the <literal>waveform</literal> key is, itself,
+                                            a dict with the keys <literal>name</literal>, the name of the waveform,
+                                            <literal>samples</literal>, a list of integer valued waveform samples,
+                                            and <literal>rank</literal>, an integer identifying the source of this
+                                            information.  The <literal>rank</literal> value
+                                            will be zero for serial SpecTcl and an integer
+                                            2 or larger for MPISpecTcl identifying the worker process that
+                                            contributed this information.
+                                        </para>
+                                        <para>
+                                            The contents of the <literal>fits</literal> key is a list of dicts,
+                                            one for each fit.  The dicts contain the keys:
+                                            <literal>name</literal>, then name of the fit, and <literal>points</literal>
+                                            a list of real valued points.  There will be one point for each waveform
+                                            sample.
+                                        </para>
+                                    </listitem>
                             </varlistentry>
                         </variablelist>
                         

--- a/main/restclient/restclientdocs.xml
+++ b/main/restclient/restclientdocs.xml
@@ -3894,7 +3894,9 @@ c destroy                                     <co id='ex.client.destroy' />
                                         <para>
                                             The <parameter>name</parameter> specifies the name of the
                                             waveform for which data will be returned.  The returned value
-                                            is a dict that has the keys <literal>waveform</literal>
+                                            is a dict that has the keys 
+                                            <literal>name</literal>, the name of the waveform, 
+                                            <literal>waveform</literal>
                                             and <literal>fits</literal>
                                         </para>
                                         <para>

--- a/main/restclient/restclientdocs.xml
+++ b/main/restclient/restclientdocs.xml
@@ -270,7 +270,7 @@ c destroy                                     <co id='ex.client.destroy' />
                     <programlisting>
     package require SpecTclRESTClient
     
-    set client [SpecTclRestClient client-spec ?options...?]
+    set client [SpecTclRestClient obj-name|%AUTO% client-spec ?options...?]
     $client configure option value ?...?
     set value [$client cget option]
     
@@ -417,7 +417,15 @@ c destroy                                     <co id='ex.client.destroy' />
                         Instantiating an object creates a new command ensemble.
                         Subcommands perform specific REST transactions.
                       </para>
-                      
+                      <para>
+                        The implementation of the interface is done using the
+                        snit object oriented programming extension to Tcl.
+                        This means that when constructing an interface object,
+                        you supply the name of the object you want constructed or
+                        the special name %AUTO% to allow snit to create the object
+                        name for you.  Additional options (see <literal>OPTIONS</literal> below),
+                        define how the interface object connects to the SpecTcl ReST server.
+                      </para>
                 </refsect1>
                 <refsect1>
                     <title>OPTIONS</title>

--- a/main/rootxamine/Makefile.am
+++ b/main/rootxamine/Makefile.am
@@ -20,7 +20,7 @@ BUILT_SOURCES=cmdline.h cmdline.c @builddir@/docs_built
 
 noinst_HEADERS=cmdline.h
 
-install-exec-local:
+install-exec-local: @builddir@/docs_built
 	$(mkinstalldirs) @prefix@/share/rootxamine
 	$(INSTALL_DATA) @builddir@/rootxamine_docs/* @prefix@/share/rootxamine
 
@@ -32,5 +32,9 @@ cmdline.h cmdline.c : @srcdir@/rxoptions.ggo
 @builddir@/docs_built : @srcdir@/rootxamine.xml
 	@HTMLDOCBOOK@ @srcdir@/rootxamine.xml -o @builddir@/rootxamine_docs
 	touch @builddir@/docs_built
+
+distclean-hook:
+	rm -f docs_built
+	rm -rf rootxamine_docs
 
 EXTRA_DIST=rxoptions.ggo rootxamine.xml

--- a/main/treegui/waveformtab.tcl
+++ b/main/treegui/waveformtab.tcl
@@ -47,6 +47,7 @@ snit::widget WaveformWidget {
     component listing
     component mdeditor
     component wfplot
+    delegate method addFit to wfplot;   # Expose the addFit method to the controller.
 
     option -selectscript
     option -waveform -configuremethod _setWaveform
@@ -64,6 +65,8 @@ snit::widget WaveformWidget {
         grid $wfplot -columnspan 2
 
         $self configurelist $args
+
+        
     }
 
     # Public methods:
@@ -78,6 +81,7 @@ snit::widget WaveformWidget {
     #     be a trace from each worker.
     #
     method plot data {
+        
         set name [lindex $data 0]
         set trace [lindex $data 1]
         $wfplot configure -name $name -samples $trace
@@ -567,6 +571,15 @@ snit::widget MetadataPrompter {
 #   -samples - Waveform samples - setting updates the plot.
 #   -command - Script to execute when an update is required/requested.
 #
+# METHODS:
+#    addFit - adds a fit to the existing plot. 
+#
+# @note This stuff means that there is a defined order of operations
+#   that must be followed:
+#    1.  -samples must be set to create the plot.
+#    2.  If desired, -name can be set to title the plot.
+#    3.  0 or more callse to addFit can be made to superimpose
+#       fit lines on the plot.
 # In this initial version only buttons update the display. Future version may
 # provide for timed update requests.
 #
@@ -586,6 +599,15 @@ snit::widget WaveformDisplay {
 
     variable plotName "";         # Name of the plot chart plot.
 
+    # fitColors is the set of colors the fit lines cycle through.
+    # fitColorIndex is the index of the next fit color in that list.
+
+    variable fitColors [list               \
+        red green blue magenta cyan yellow \
+        "dark green" brown "hot pink"      \
+    ]
+    variable fitColorIndex 0
+
     #  Canvas dimensions so we can easily change them as we tweak.
     variable height 500
     variable width 800
@@ -604,6 +626,33 @@ snit::widget WaveformDisplay {
     destructor {
         if {$plotName ne ""} {
             destroy $plotName;    # Kill any hanging plot.
+        }
+    }
+    # Public methods:
+    #
+
+    ##
+    # addFit name points
+    #   Adds a fit line to the existing plot.  -samples must have
+    #   been configured first.
+    #   * The fit name is used to construct the series name as fit.fitname
+    #   * The Series is added to the legend as "Fit: fitname"
+    #
+    #  @param name - name of the fit.
+    #  @param points - fit points.
+    #
+    method addFit {name points} {
+        if {$plotName ne ""} {
+            # Make the x points:
+
+            set xpts [_xpoints $points]
+            set seriesName "fit.$name"
+            set seriesTitle "Fit: $name"
+
+            $plotName dataconfig $seriesName -type line -color [$self _nextColor]
+            $plotName plotlist $seriesName $xpts $points [llength $points]
+            $plotName legend $seriesName $seriesTitle
+
         }
     }
     # Private methods:
@@ -649,6 +698,7 @@ snit::widget WaveformDisplay {
             destroy $plotName
             set plotName ""
         }
+        set fitColorIndex 0;    # Reset the color index.
         # Figure out our axis ranges and labels.
 
         set xaxis [list 0 [llength $options($opt)] ""]
@@ -673,11 +723,25 @@ snit::widget WaveformDisplay {
         $plotName legend trace waveform
         
 
-        $plotname legendconfig -position top-right
+        $plotName legendconfig -position top-right
 
         
     }
+    #  _nextColor
+    #    Return the next fit color in the fit color cycle:
+    #
+    method _nextColor {} {
+        set result [lindex $fitColors $fitColorIndex]
+        
+        
+        # Next fitColorIndex, Cycle if needed.
+        incr fitColorIndex
+        if {$fitColorIndex >= [llength $fitColors]} {
+            set fitColorIndex 0
+        }
 
+        return $result
+    }
     #  Utility proces:
 
     #  _ymax - compute the max of a plot given its points.
@@ -812,9 +876,19 @@ snit::type WaveformController {
     # @param name - name of the waveform.
     #
     method _plot name {
-        set points [waveform get $name]
-        set points [lindex $points 0] ;   # Could be several waveforms.
+        
+        set wfinfo [lindex [waveform getall $name] 0];    # dict of all:
+        # Plot the trace:
 
+        set points [dict get $wfinfo waveform]
+       # set points [lindex $points 0] ;   # Could be several waveforms. each is name points 
+        
         $options(-view) plot $points
+
+        # Plot ach fit:
+
+        foreach fit [dict get $wfinfo fits] {
+            $options(-view) addFit [dict get $fit name] [dict get $fit points]
+        }
     }
 }

--- a/main/treegui/waveformtab.tcl
+++ b/main/treegui/waveformtab.tcl
@@ -658,18 +658,24 @@ snit::widget WaveformDisplay {
         # Generate the canvas and plot:
         canvas $win.plot -width $width -height $height
         grid $win.plot -row 0 -column 0
+        
         set plotName [Plotchart::createXYPlot $win.plot $xaxis $yaxis \
             -xlabels $xlabels -ylabels $ylabels          \
         ]
+        
         $plotName title $options(-name) top;   #  Title (if ther's none it'll be blank).
-
         #  Generate the x series:
 
         set xpts [_xpoints $options($opt)]
 
         $plotName plotlist trace $xpts $options($opt) [llength $options($opt)]
         $plotName dataconfig trace -type line
+        $plotName legend trace waveform
+        
 
+        $plotname legendconfig -position top-right
+
+        
     }
 
     #  Utility proces:
@@ -680,6 +686,9 @@ snit::widget WaveformDisplay {
     proc _ymax series {
         set max [expr max([join $series ,])]
         set max [expr 1.05*$max]
+        if {$max == 0} {
+            set max 100.0
+        }
         return $max
     }
 
@@ -698,7 +707,9 @@ snit::widget WaveformDisplay {
     proc _labels {axis interval} {
         set max [lindex $axis 1]
         set result [list]
-
+        if {$max == 0} {
+            return [list 0.0 500.0]
+        }
         for {set i 0} {$i <= $max} {incr i $interval} {
             lappend result $i
         }


### PR DESCRIPTION
Resovle the SpecTcl side of issue #212. 
* SpecTcl waveform objects can now have an arbitrary number of named fits associated with them.
* The SpecTcl waveform command has new subcommands fits and getall.
* The Tree GUI waveform tab supermiposes fit points on the waveform plots.
* The ReST server waveform domain adds the methods fits and getall to expose the the new waveform subcommands.
* The ReST Tcl low level client has new methods waveformListFits and waveformGetAll that expose the new waveform subcommands.
* The ReST client SpecTcl command emulator includes the new waveform subcommands above.
* cmdref documentation updated.
* programming guide and reference updated.
* restdocs updated, as are rest client docs.