### PR TITLE
Issue #250 - make Qtpy the default displayer.

### DIFF
--- a/main/Core/TclGrammerApp.cpp
+++ b/main/Core/TclGrammerApp.cpp
@@ -97,6 +97,7 @@ static const char* Copyright = "(C) Copyright Michigan State University 2008, Al
 #include <iostream>
 #include <stdio.h>
 #include <stdlib.h>
+#include <time.h>
 #include <assert.h>
 #include <histotypes.h>
 #include <buftypes.h>
@@ -265,7 +266,7 @@ CTclGrammerApp::CTclGrammerApp() :
   m_nDisplaySize(knDisplaySize),
   m_nParams(knParameterCount),
   m_nListSize(knEventListSize),
-  m_displayType("xamine"),
+  m_displayType("qtpy"),
   m_pAnalyzer(0),
   m_pHistogrammer(0),
   m_pDecoder(0),
@@ -967,6 +968,10 @@ int CTclGrammerApp::operator()() {
   try {
   // Fetch and setup the interpreter member/global pointer.
   gpInterpreter = getInterpreter();
+
+  /* Issue #250 - set default ports for httpd and mirror: */
+
+  setDefaultServerPorts();
   
   // Fix for issue #122: suppress <RootX11ErrorHandler> messages:
   gErrorIgnoreLevel = kFatal;
@@ -1305,6 +1310,33 @@ void
 CTclGrammerApp::protectVariable(CTCLInterpreter* pInterp, const char* pVarName)
 {
   new CSpecTclInitVar(pInterp, pVarName);
+}
+/**
+ * With SpecTcl now defaulting to the qtpy displayer (Issue #250), we
+ * need to ensure the servers get started on, hopefully, unique ports.
+ * We randomize a pair of ports and set the interpreter variables:
+ * HTTPDPort and MirrorPort to those port numbers.
+ * 
+ * This must be run after the interpreter has been created.
+ */
+void
+CTclGrammerApp::setDefaultServerPorts() {
+  // Seed the interger random number generator:
+
+  srandom(time(nullptr));
+  int restPort = (random() & 0x7fff) | 0x8000;  // Range of 0x8000 - 0xffff.
+  int mirrorPort = (random() &0x7fff) | 0x8000;
+  std::string sRestPort = std::to_string(restPort);
+  std::string sMirrorPort = std::to_string(mirrorPort);
+
+  // Make and set the variables:
+
+  CTCLVariable restVar(getInterpreter(), "HTTPDPort", false);
+  restVar.Set(sRestPort.c_str());
+
+  CTCLVariable mirrorVar(getInterpreter(), "MirrorPort", false);
+  mirrorVar.Set(sMirrorPort.c_str());
+
 }
 
 

--- a/main/Core/TclGrammerApp.h
+++ b/main/Core/TclGrammerApp.h
@@ -363,7 +363,7 @@ protected:
 private:
   static void TimedUpdates(ClientData d);
   void protectVariable(CTCLInterpreter* pInterp, const char* pVarName);
-
+  void setDefaultServerPorts();
   /*!
    * \brief AppInit - Set up application
    *

--- a/main/SpecTcl/SpecTclInit.tcl
+++ b/main/SpecTcl/SpecTclInit.tcl
@@ -20,5 +20,5 @@ set EventListSize    1
 set ParameterOverwriteAction query
 set SpectrumOverwriteAction  query
 set splashImage $SpecTclHome/share/html/images/hh00706_.jpg;   # SpecTcl icon for splashscreen.
-#set DisplayType spectra
-set DisplayType xamine
+
+set DisplayType qtpy


### PR DESCRIPTION
*  Set display type in SpecTclInit.tcl that's installed in $SpecTclHome/etc
*  Set constrictor DisplayType default value in TclGrammerApp.cpp
*  Add random port assignment for HTTPD and Mirror servers so those two services always start now.
Resolve issue #250 for 5.14